### PR TITLE
Release crates.io patch updates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1972,7 +1972,7 @@ dependencies = [
 
 [[package]]
 name = "rns-core"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "log",
  "rns-crypto",
@@ -1981,7 +1981,7 @@ dependencies = [
 
 [[package]]
 name = "rns-crypto"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "aes",
  "cbc",
@@ -1995,7 +1995,7 @@ dependencies = [
 
 [[package]]
 name = "rns-ctl"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "env_logger 0.11.8",
  "libc",
@@ -2034,7 +2034,7 @@ dependencies = [
 
 [[package]]
 name = "rns-net"
-version = "0.5.4"
+version = "0.5.5"
 dependencies = [
  "bincode",
  "bzip2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,16 +4,16 @@ exclude = ["rns-esp32"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.4"
+version = "0.1.5"
 edition = "2021"
 license-file = "LICENSE"
 repository = "https://github.com/lelloman/rns-rs"
 authors = ["rns-rs contributors"]
 
 [workspace.dependencies]
-rns-crypto = { version = "0.1.4", path = "rns-crypto" }
-rns-core = { version = "0.1.7", path = "rns-core" }
-rns-net = { version = "0.5.4", path = "rns-net" }
+rns-crypto = { version = "0.1.5", path = "rns-crypto" }
+rns-core = { version = "0.1.8", path = "rns-core" }
+rns-net = { version = "0.5.5", path = "rns-net" }
 rns-hooks = { version = "0.1.5", path = "rns-hooks" }
 
 # Compile crypto crate with optimizations even in debug/test builds.

--- a/rns-core/Cargo.toml
+++ b/rns-core/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rns-core"
 description = "Wire protocol, transport routing, and link/resource engine for the Reticulum Network Stack"
-version = "0.1.7"
+version = "0.1.8"
 edition.workspace = true
 license-file.workspace = true
 repository.workspace = true

--- a/rns-ctl/Cargo.toml
+++ b/rns-ctl/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rns-ctl"
 description = "Reticulum Network Stack control tool"
-version = "0.2.3"
+version = "0.2.4"
 edition.workspace = true
 license-file.workspace = true
 repository.workspace = true

--- a/rns-net/Cargo.toml
+++ b/rns-net/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rns-net"
 description = "Network interfaces and node driver for the Reticulum Network Stack"
-version = "0.5.4"
+version = "0.5.5"
 edition.workspace = true
 license-file.workspace = true
 repository.workspace = true


### PR DESCRIPTION
Publishes the crates.io patch release state already released from commit 5d61f057682071814cae52dba0ef74dcc038f261.\n\nPublished crates:\n- rns-crypto 0.1.5\n- rns-core 0.1.8\n- rns-net 0.5.5\n- rns-ctl 0.2.4\n\nVerification performed:\n- cargo check --workspace\n- cargo test --workspace -- --test-threads=1\n- cargo publish --dry-run for each published crate in dependency order\n- crates.io API confirmed newest versions