### PR TITLE
Fix NomadNet response resource transfer on negotiated MTUs

### DIFF
--- a/rns-core/src/link/mod.rs
+++ b/rns-core/src/link/mod.rs
@@ -505,6 +505,10 @@ impl LinkEngine {
         self.mdu
     }
 
+    pub fn mtu(&self) -> u32 {
+        self.mtu
+    }
+
     pub fn is_initiator(&self) -> bool {
         self.is_initiator
     }

--- a/rns-core/src/packet.rs
+++ b/rns-core/src/packet.rs
@@ -93,6 +93,27 @@ impl RawPacket {
         context: u8,
         data: &[u8],
     ) -> Result<Self, PacketError> {
+        Self::pack_with_max_mtu(
+            flags,
+            hops,
+            destination_hash,
+            transport_id,
+            context,
+            data,
+            constants::MTU,
+        )
+    }
+
+    /// Pack fields into raw bytes with a caller-provided MTU limit.
+    pub fn pack_with_max_mtu(
+        flags: PacketFlags,
+        hops: u8,
+        destination_hash: &[u8; 16],
+        transport_id: Option<&[u8; 16]>,
+        context: u8,
+        data: &[u8],
+        max_mtu: usize,
+    ) -> Result<Self, PacketError> {
         if flags.header_type == constants::HEADER_2 && transport_id.is_none() {
             return Err(PacketError::MissingTransportId);
         }
@@ -109,7 +130,7 @@ impl RawPacket {
         raw.push(context);
         raw.extend_from_slice(data);
 
-        if raw.len() > constants::MTU {
+        if raw.len() > max_mtu {
             return Err(PacketError::ExceedsMtu);
         }
 

--- a/rns-core/src/transport/mod.rs
+++ b/rns-core/src/transport/mod.rs
@@ -1365,13 +1365,11 @@ impl TransportEngine {
             {
                 let link_entry = self.link_table.get(&packet.destination_hash).cloned();
                 if let Some(entry) = link_entry {
-                    if packet.hops == entry.remaining_hops && iface == entry.next_hop_interface {
+                    if let Some((outbound_interface, new_raw)) =
+                        route_via_link_table(packet, &entry, iface)
+                    {
                         // Forward the proof (simplified: skip signature validation
                         // which requires Identity recall)
-                        let mut new_raw = Vec::new();
-                        new_raw.push(packet.raw[0]);
-                        new_raw.push(packet.hops);
-                        new_raw.extend_from_slice(&packet.raw[2..]);
 
                         // Mark link as validated
                         if let Some(le) = self.link_table.get_mut(&packet.destination_hash) {
@@ -1380,11 +1378,11 @@ impl TransportEngine {
 
                         actions.push(TransportAction::LinkEstablished {
                             link_id: packet.destination_hash,
-                            interface: entry.received_interface,
+                            interface: outbound_interface,
                         });
 
                         actions.push(TransportAction::SendOnInterface {
-                            interface: entry.received_interface,
+                            interface: outbound_interface,
                             raw: new_raw,
                         });
                     }

--- a/rns-core/src/transport/mod.rs
+++ b/rns-core/src/transport/mod.rs
@@ -2518,6 +2518,71 @@ mod tests {
     }
 
     #[test]
+    fn test_lrproof_routes_from_originating_side_via_link_table() {
+        let mut engine = TransportEngine::new(make_config(true));
+        engine.register_interface(make_interface(1, constants::MODE_FULL));
+        engine.register_interface(make_interface(2, constants::MODE_FULL));
+
+        let link_id = [0x44; 16];
+        engine.register_link(
+            link_id,
+            LinkEntry {
+                timestamp: 100.0,
+                next_hop_transport_id: [0xAA; 16],
+                next_hop_interface: InterfaceId(2),
+                remaining_hops: 3,
+                received_interface: InterfaceId(1),
+                taken_hops: 1,
+                destination_hash: [0xBB; 16],
+                validated: false,
+                proof_timeout: 200.0,
+            },
+        );
+
+        let flags = PacketFlags {
+            header_type: constants::HEADER_1,
+            context_flag: constants::FLAG_UNSET,
+            transport_type: constants::TRANSPORT_BROADCAST,
+            destination_type: constants::DESTINATION_LINK,
+            packet_type: constants::PACKET_TYPE_PROOF,
+        };
+        let packet = RawPacket::pack(
+            flags,
+            0,
+            &link_id,
+            None,
+            constants::CONTEXT_LRPROOF,
+            &[0xCC; 64],
+        )
+        .unwrap();
+        let mut rng = rns_crypto::FixedRng::new(&[0x33; 32]);
+
+        let actions = engine.handle_inbound(&packet.raw, InterfaceId(1), 101.0, &mut rng);
+
+        assert!(matches!(
+            engine
+                .link_table_ref()
+                .get(&link_id)
+                .map(|entry| entry.validated),
+            Some(true)
+        ));
+        assert!(actions.iter().any(|action| matches!(
+            action,
+            TransportAction::LinkEstablished {
+                link_id: established,
+                interface: InterfaceId(2),
+            } if *established == link_id
+        )));
+        assert!(actions.iter().any(|action| matches!(
+            action,
+            TransportAction::SendOnInterface {
+                interface: InterfaceId(2),
+                ..
+            }
+        )));
+    }
+
+    #[test]
     fn test_packet_filter_drops_plain_announce() {
         let engine = TransportEngine::new(make_config(false));
         let flags = PacketFlags {

--- a/rns-net/src/common/link_manager.rs
+++ b/rns-net/src/common/link_manager.rs
@@ -61,6 +61,13 @@ struct ManagedLink {
     outgoing_resources: Vec<ResourceSender>,
     /// Resource acceptance strategy.
     resource_strategy: ResourceStrategy,
+    /// Interface this link's packets should be sent on when known.
+    route_interface: Option<rns_core::transport::types::InterfaceId>,
+    /// Next-hop transport ID seen on inbound HEADER_2 link traffic.
+    ///
+    /// When present, outbound link packets can be rewritten to HEADER_2 using
+    /// this transport ID to preserve multi-hop routing.
+    route_transport_id: Option<[u8; 16]>,
 }
 
 /// A registered link destination that can accept incoming LINKREQUEST.
@@ -210,6 +217,17 @@ impl LinkManager {
             .and_then(|link| link.engine.derived_key().map(|dk| dk.to_vec()))
     }
 
+    /// Return best-known routing hint for link packets.
+    pub fn get_link_route_hint(
+        &self,
+        link_id: &LinkId,
+    ) -> Option<(rns_core::transport::types::InterfaceId, Option<[u8; 16]>)> {
+        self.links.get(link_id).and_then(|link| {
+            link.route_interface
+                .map(|iface| (iface, link.route_transport_id))
+        })
+    }
+
     /// Register a destination that can accept incoming links.
     pub fn register_link_destination(
         &mut self,
@@ -320,6 +338,8 @@ impl LinkManager {
             incoming_resources: Vec::new(),
             outgoing_resources: Vec::new(),
             resource_strategy: ResourceStrategy::default(),
+            route_interface: None,
+            route_transport_id: None,
         };
         self.links.insert(link_id, managed);
 
@@ -360,11 +380,11 @@ impl LinkManager {
             }
             constants::PACKET_TYPE_PROOF if packet.context == constants::CONTEXT_LRPROOF => {
                 // LRPROOF: dest_hash is the link_id
-                self.handle_lrproof(&dest_hash, &packet, rng)
+                self.handle_lrproof(&dest_hash, &packet, receiving_interface, rng)
             }
             constants::PACKET_TYPE_PROOF => self.handle_link_proof(&dest_hash, &packet, rng),
             constants::PACKET_TYPE_DATA => {
-                self.handle_link_data(&dest_hash, &packet, packet_hash, rng)
+                self.handle_link_data(&dest_hash, &packet, packet_hash, receiving_interface, rng)
             }
             _ => Vec::new(),
         }
@@ -406,6 +426,14 @@ impl LinkManager {
         };
 
         let link_id = *engine.link_id();
+        log::debug!(
+            "LINKREQUEST accepted: link={:02x?} iface={} header_type={} transport_id_present={} hops={}",
+            &link_id[..4],
+            receiving_interface.0,
+            packet.flags.header_type,
+            packet.transport_id.is_some(),
+            packet.hops
+        );
 
         let managed = ManagedLink {
             engine,
@@ -424,6 +452,12 @@ impl LinkManager {
             incoming_resources: Vec::new(),
             outgoing_resources: Vec::new(),
             resource_strategy: ld.resource_strategy,
+            route_interface: Some(receiving_interface),
+            route_transport_id: if packet.flags.header_type == constants::HEADER_2 {
+                packet.transport_id
+            } else {
+                None
+            },
         };
         self.links.insert(link_id, managed);
 
@@ -443,17 +477,75 @@ impl LinkManager {
 
         if let Ok(pkt) = RawPacket::pack(
             flags,
-            0,
+            packet.hops,
             &link_id,
             None,
             constants::CONTEXT_LRPROOF,
             &lrproof_data,
         ) {
+            log::debug!(
+                "LRPROOF queued: link={:02x?} route_iface={} route_tid_present={} hops={}",
+                &link_id[..4],
+                receiving_interface.0,
+                packet.transport_id.is_some(),
+                packet.hops
+            );
             actions.push(LinkManagerAction::SendPacket {
                 raw: pkt.raw,
                 dest_type: constants::DESTINATION_LINK,
                 attached_interface: None,
             });
+        }
+
+        // Compatibility fallback #1: some stacks validate LRPROOF only when
+        // proof packets retain hop=0 semantics.
+        if packet.hops != 0 {
+            if let Ok(pkt0) = RawPacket::pack(
+                flags,
+                0,
+                &link_id,
+                None,
+                constants::CONTEXT_LRPROOF,
+                &lrproof_data,
+            ) {
+                log::debug!(
+                    "LRPROOF fallback queued: link={:02x?} route_iface={} hops=0",
+                    &link_id[..4],
+                    receiving_interface.0
+                );
+                actions.push(LinkManagerAction::SendPacket {
+                    raw: pkt0.raw,
+                    dest_type: constants::DESTINATION_LINK,
+                    attached_interface: None,
+                });
+            }
+        }
+
+        // Compatibility fallback #2: some transport implementations compare
+        // LRPROOF hops against a "remaining hops" value derived differently
+        // from destination-side delivery hops. Queue a +1 hop variant too.
+        if packet.hops < u8::MAX {
+            let hops_plus_one = packet.hops + 1;
+            if let Ok(pkt2) = RawPacket::pack(
+                flags,
+                hops_plus_one,
+                &link_id,
+                None,
+                constants::CONTEXT_LRPROOF,
+                &lrproof_data,
+            ) {
+                log::debug!(
+                    "LRPROOF +1 queued: link={:02x?} route_iface={} hops={}",
+                    &link_id[..4],
+                    receiving_interface.0,
+                    hops_plus_one
+                );
+                actions.push(LinkManagerAction::SendPacket {
+                    raw: pkt2.raw,
+                    dest_type: constants::DESTINATION_LINK,
+                    attached_interface: None,
+                });
+            }
         }
 
         // Notify hook system about the incoming link request
@@ -546,12 +638,27 @@ impl LinkManager {
         &mut self,
         link_id_bytes: &[u8; 16],
         packet: &RawPacket,
+        receiving_interface: rns_core::transport::types::InterfaceId,
         rng: &mut dyn Rng,
     ) -> Vec<LinkManagerAction> {
         let link = match self.links.get_mut(link_id_bytes) {
             Some(l) => l,
             None => return Vec::new(),
         };
+
+        link.route_interface = Some(receiving_interface);
+        if packet.flags.header_type == constants::HEADER_2 {
+            if let Some(transport_id) = packet.transport_id {
+                link.route_transport_id = Some(transport_id);
+            }
+        }
+        log::debug!(
+            "LRPROOF received: link={:02x?} iface={} header_type={} transport_id_present={}",
+            &link_id_bytes[..4],
+            receiving_interface.0,
+            packet.flags.header_type,
+            packet.transport_id.is_some()
+        );
 
         if link.engine.state() != LinkState::Pending || !link.engine.is_initiator() {
             return Vec::new();
@@ -630,6 +737,7 @@ impl LinkManager {
         link_id_bytes: &[u8; 16],
         packet: &RawPacket,
         packet_hash: [u8; 32],
+        receiving_interface: rns_core::transport::types::InterfaceId,
         rng: &mut dyn Rng,
     ) -> Vec<LinkManagerAction> {
         // First pass: perform engine operations, collect results
@@ -722,6 +830,13 @@ impl LinkManager {
                 Some(l) => l,
                 None => return Vec::new(),
             };
+
+            link.route_interface = Some(receiving_interface);
+            if packet.flags.header_type == constants::HEADER_2 {
+                if let Some(transport_id) = packet.transport_id {
+                    link.route_transport_id = Some(transport_id);
+                }
+            }
 
             match packet.context {
                 constants::CONTEXT_LRRTT => {

--- a/rns-net/src/common/link_manager.rs
+++ b/rns-net/src/common/link_manager.rs
@@ -191,6 +191,18 @@ pub struct LinkManager {
 }
 
 impl LinkManager {
+    fn resource_sdu_for_link(link: &ManagedLink) -> usize {
+        // Python parity: Resource.sdu = link.mtu - HEADER_MAXSIZE - IFAC_MIN_SIZE
+        // when MTU signalling is available on the link.
+        let mtu = link.engine.mtu() as usize;
+        let derived = mtu.saturating_sub(constants::HEADER_MAXSIZE + constants::IFAC_MIN_SIZE);
+        if derived > 0 {
+            derived
+        } else {
+            constants::RESOURCE_SDU
+        }
+    }
+
     /// Create a new empty link manager.
     pub fn new() -> Self {
         LinkManager {
@@ -497,8 +509,8 @@ impl LinkManager {
             });
         }
 
-        // Compatibility fallback #1: some stacks validate LRPROOF only when
-        // proof packets retain hop=0 semantics.
+        // Reticulum interop fallback #1: queue an LRPROOF variant with
+        // hop=0, matching peers that validate LRPROOF with hop=0 semantics.
         if packet.hops != 0 {
             if let Ok(pkt0) = RawPacket::pack(
                 flags,
@@ -521,9 +533,9 @@ impl LinkManager {
             }
         }
 
-        // Compatibility fallback #2: some transport implementations compare
-        // LRPROOF hops against a "remaining hops" value derived differently
-        // from destination-side delivery hops. Queue a +1 hop variant too.
+        // Reticulum interop fallback #2: queue an LRPROOF +1 hop variant for
+        // peers that validate against a remaining-hop value derived
+        // differently from destination-side delivery hops.
         if packet.hops < u8::MAX {
             let hops_plus_one = packet.hops + 1;
             if let Ok(pkt2) = RawPacket::pack(
@@ -768,7 +780,7 @@ impl LinkManager {
                 link_id: LinkId,
                 inbound_actions: Vec<LinkAction>,
                 plaintext: Vec<u8>,
-                packet_hash: [u8; 32],
+                request_id: [u8; 16],
             },
             Response {
                 link_id: LinkId,
@@ -903,11 +915,12 @@ impl LinkManager {
                     Ok(plaintext) => {
                         let inbound_actions = link.engine.record_inbound(time::now());
                         let link_id = *link.engine.link_id();
+                        let request_id = packet.get_truncated_hash();
                         LinkDataResult::Request {
                             link_id,
                             inbound_actions,
                             plaintext,
-                            packet_hash,
+                            request_id,
                         }
                     }
                     Err(_) => LinkDataResult::Error,
@@ -1089,10 +1102,10 @@ impl LinkManager {
                 link_id,
                 inbound_actions,
                 plaintext,
-                packet_hash,
+                request_id,
             } => {
                 actions.extend(self.process_link_actions(&link_id, &inbound_actions));
-                actions.extend(self.handle_request(&link_id, &plaintext, packet_hash, rng));
+                actions.extend(self.handle_request(&link_id, &plaintext, request_id, rng));
             }
             LinkDataResult::Response {
                 link_id,
@@ -1184,7 +1197,7 @@ impl LinkManager {
         &mut self,
         link_id: &LinkId,
         plaintext: &[u8],
-        packet_hash: [u8; 32],
+        request_id: [u8; 16],
         rng: &mut dyn Rng,
     ) -> Vec<LinkManagerAction> {
         use rns_core::msgpack::{self, Value};
@@ -1201,18 +1214,6 @@ impl LinkManager {
         };
         let mut path_hash = [0u8; 16];
         path_hash.copy_from_slice(path_hash_bytes);
-
-        // Python-compatible request_id: Packet.getTruncatedHash(), i.e.
-        // first 16 bytes of the full packet hash computed from hashable part.
-        //
-        // IMPORTANT: This is *not* truncated_hash(plaintext). Using plaintext
-        // here causes interop failures with Python clients (eg. MeshChat),
-        // because they match responses by packet-truncated-hash request IDs.
-        let request_id = {
-            let mut id = [0u8; 16];
-            id.copy_from_slice(&packet_hash[..16]);
-            id
-        };
 
         // Re-encode the data element for the handler
         let request_data = msgpack::pack(&arr[2]);
@@ -1270,7 +1271,17 @@ impl LinkManager {
 
         let mut actions = Vec::new();
         if let Some(response_data) = response {
-            actions.extend(self.build_response_packet(link_id, &request_id, &response_data, rng));
+            let mut response_actions =
+                self.build_response_packet(link_id, &request_id, &response_data, rng);
+            if response_actions.is_empty() {
+                response_actions.extend(self.send_response_resource(
+                    link_id,
+                    &request_id,
+                    &response_data,
+                    rng,
+                ));
+            }
+            actions.extend(response_actions);
         }
 
         actions
@@ -1321,6 +1332,75 @@ impl LinkManager {
             }
         }
         actions
+    }
+
+    fn send_response_resource(
+        &mut self,
+        link_id: &LinkId,
+        request_id: &[u8; 16],
+        response_data: &[u8],
+        rng: &mut dyn Rng,
+    ) -> Vec<LinkManagerAction> {
+        use rns_core::msgpack::{self, Value};
+
+        let link = match self.links.get_mut(link_id) {
+            Some(l) => l,
+            None => return Vec::new(),
+        };
+
+        if link.engine.state() != LinkState::Active {
+            return Vec::new();
+        }
+
+        let link_rtt = link.engine.rtt().unwrap_or(1.0);
+        let resource_sdu = Self::resource_sdu_for_link(link);
+        let now = time::now();
+
+        let enc_rng = std::cell::RefCell::new(rns_crypto::OsRng);
+        let encrypt_fn = |plaintext: &[u8]| -> Vec<u8> {
+            link.engine
+                .encrypt(plaintext, &mut *enc_rng.borrow_mut())
+                .unwrap_or_else(|_| plaintext.to_vec())
+        };
+
+        // Match Python resource response format from Link.handle_request:
+        // packed_response = msgpack([request_id, response_value])
+        // where response_value is decoded msgpack value, or Bin(raw bytes).
+        let response_value = msgpack::unpack_exact(response_data)
+            .unwrap_or_else(|_| Value::Bin(response_data.to_vec()));
+        let response_array = Value::Array(vec![Value::Bin(request_id.to_vec()), response_value]);
+        let resource_payload = msgpack::pack(&response_array);
+
+        let sender = match ResourceSender::new(
+            &resource_payload,
+            None,
+            resource_sdu,
+            &encrypt_fn,
+            &Bzip2Compressor,
+            rng,
+            now,
+            true, // auto_compress
+            true, // is_response
+            Some(request_id.to_vec()),
+            1,    // segment_index
+            1,    // total_segments
+            None, // original_hash
+            link_rtt,
+            6.0, // traffic_timeout_factor
+        ) {
+            Ok(s) => s,
+            Err(e) => {
+                log::debug!("Failed to create response ResourceSender: {}", e);
+                return Vec::new();
+            }
+        };
+
+        let mut sender = sender;
+        let adv_actions = sender.advertise(now);
+        link.outgoing_resources.push(sender);
+
+        let _ = link;
+        self.process_resource_actions(link_id, adv_actions, rng)
     }
 
     /// Send a management response on a link.
@@ -1571,11 +1651,12 @@ impl LinkManager {
         };
 
         let link_rtt = link.engine.rtt().unwrap_or(1.0);
+        let resource_sdu = Self::resource_sdu_for_link(link);
         let now = time::now();
 
         let receiver = match ResourceReceiver::from_advertisement(
             adv_plaintext,
-            constants::RESOURCE_SDU,
+            resource_sdu,
             link_rtt,
             now,
             None,
@@ -1963,7 +2044,13 @@ impl LinkManager {
             packet_type: constants::PACKET_TYPE_DATA,
         };
         let mut actions = Vec::new();
-        if let Ok(pkt) = RawPacket::pack(flags, 0, link_id, None, context, data) {
+        let max_mtu = self
+            .links
+            .get(link_id)
+            .map(|l| l.engine.mtu() as usize)
+            .unwrap_or(constants::MTU);
+        if let Ok(pkt) = RawPacket::pack_with_max_mtu(flags, 0, link_id, None, context, data, max_mtu)
+        {
             actions.push(LinkManagerAction::SendPacket {
                 raw: pkt.raw,
                 dest_type: constants::DESTINATION_LINK,
@@ -1991,6 +2078,7 @@ impl LinkManager {
         }
 
         let link_rtt = link.engine.rtt().unwrap_or(1.0);
+        let resource_sdu = Self::resource_sdu_for_link(link);
         let now = time::now();
 
         // Use RefCell for interior mutability since ResourceSender::new expects &dyn Fn (not FnMut)
@@ -2005,7 +2093,7 @@ impl LinkManager {
         let sender = match ResourceSender::new(
             data,
             metadata,
-            constants::RESOURCE_SDU,
+            resource_sdu,
             &encrypt_fn,
             &Bzip2Compressor,
             rng,

--- a/rns-net/src/common/link_manager.rs
+++ b/rns-net/src/common/link_manager.rs
@@ -1298,7 +1298,6 @@ impl LinkManager {
     ) -> Vec<LinkManagerAction> {
         use rns_core::msgpack::{self, Value};
 
-        // Python-compatible response: msgpack([Bin(request_id), response_value])
         let response_value = msgpack::unpack_exact(response_data)
             .unwrap_or_else(|_| Value::Bin(response_data.to_vec()));
 
@@ -1315,13 +1314,15 @@ impl LinkManager {
                     destination_type: constants::DESTINATION_LINK,
                     packet_type: constants::PACKET_TYPE_DATA,
                 };
-                if let Ok(pkt) = RawPacket::pack(
+                let max_mtu = link.engine.mtu() as usize;
+                if let Ok(pkt) = RawPacket::pack_with_max_mtu(
                     flags,
                     0,
                     link_id,
                     None,
                     constants::CONTEXT_RESPONSE,
                     &encrypted,
+                    max_mtu,
                 ) {
                     actions.push(LinkManagerAction::SendPacket {
                         raw: pkt.raw,
@@ -1406,13 +1407,22 @@ impl LinkManager {
     /// Send a management response on a link.
     /// Called by the driver after building the response for a ManagementRequest.
     pub fn send_management_response(
-        &self,
+        &mut self,
         link_id: &LinkId,
         request_id: &[u8; 16],
         response_data: &[u8],
         rng: &mut dyn Rng,
     ) -> Vec<LinkManagerAction> {
-        self.build_response_packet(link_id, request_id, response_data, rng)
+        let mut actions = self.build_response_packet(link_id, request_id, response_data, rng);
+        if actions.is_empty() {
+            actions.extend(self.send_response_resource(
+                link_id,
+                request_id,
+                response_data,
+                rng,
+            ));
+        }
+        actions
     }
 
     /// Send a request on a link.
@@ -1673,6 +1683,17 @@ impl LinkManager {
         let resource_hash = receiver.resource_hash.clone();
         let transfer_size = receiver.transfer_size;
         let has_metadata = receiver.has_metadata;
+        let is_response = receiver.flags.is_response;
+
+        if is_response {
+            // Response resources bypass the application acceptance strategy —
+            // they are answers to pending requests, not independent resources.
+            link.incoming_resources.push(receiver);
+            let idx = link.incoming_resources.len() - 1;
+            let resource_actions = link.incoming_resources[idx].accept(now);
+            let _ = link;
+            return self.process_resource_actions(link_id, resource_actions, rng);
+        }
 
         match strategy {
             ResourceStrategy::AcceptNone => {
@@ -1803,11 +1824,11 @@ impl LinkManager {
         let now = time::now();
         let mut all_actions = Vec::new();
         let mut assemble_idx = None;
+        let mut assembled_is_response = false;
 
         for (idx, receiver) in link.incoming_resources.iter_mut().enumerate() {
             let resource_actions = receiver.receive_part(raw_data, now);
             if !resource_actions.is_empty() {
-                // Check if all parts received (triggers assembly)
                 if receiver.received_count == receiver.total_parts {
                     assemble_idx = Some(idx);
                 }
@@ -1816,18 +1837,36 @@ impl LinkManager {
             }
         }
 
-        // Assemble if all parts received
         if let Some(idx) = assemble_idx {
             let decrypt_fn = |ciphertext: &[u8]| -> Result<Vec<u8>, ()> {
                 link.engine.decrypt(ciphertext).map_err(|_| ())
             };
             let assemble_actions =
                 link.incoming_resources[idx].assemble(&decrypt_fn, &Bzip2Compressor);
+            assembled_is_response = link.incoming_resources[idx].flags.is_response;
             all_actions.extend(assemble_actions);
         }
 
         let _ = link;
-        self.process_resource_actions(link_id, all_actions, rng)
+        let mut out = self.process_resource_actions(link_id, all_actions, rng);
+
+        if assembled_is_response {
+            let mut converted = Vec::new();
+            for action in out {
+                match action {
+                    LinkManagerAction::ResourceReceived { data, .. } => {
+                        converted.extend(self.handle_response(link_id, &data));
+                    }
+                    LinkManagerAction::ResourceAcceptQuery { .. } => {
+                        // Response resources bypass application acceptance
+                    }
+                    other => converted.push(other),
+                }
+            }
+            out = converted;
+        }
+
+        out
     }
 
     /// Handle resource proof (CONTEXT_RESOURCE_PRF) — feed to sender.
@@ -4017,5 +4056,182 @@ mod tests {
         let mgr = LinkManager::new();
         let fake_id = [0xAA; 16];
         assert!(mgr.link_state(&fake_id).is_none());
+    }
+
+    #[test]
+    fn test_large_response_resource_completes_as_response() {
+        let (mut init_mgr, mut resp_mgr, link_id) = setup_active_link();
+        let mut rng = OsRng;
+
+        let large_payload: Vec<u8> = (0..5000u32).map(|i| (i & 0xFF) as u8).collect();
+        let response_value =
+            rns_core::msgpack::pack(&rns_core::msgpack::Value::Bin(large_payload));
+        resp_mgr.register_request_handler("/large", None, {
+            let response_value = response_value.clone();
+            move |_link_id, _path, _data, _remote| Some(response_value.clone())
+        });
+
+        let req_actions = init_mgr.send_request(&link_id, "/large", b"\xc0", &mut rng);
+        let req_raw = extract_any_send_packet(&req_actions);
+        let req_pkt = RawPacket::unpack(&req_raw).unwrap();
+        let request_id = req_pkt.get_truncated_hash();
+        let resp_actions = resp_mgr.handle_local_delivery(
+            req_pkt.destination_hash,
+            &req_raw,
+            req_pkt.packet_hash,
+            rns_core::transport::types::InterfaceId(0),
+            &mut rng,
+        );
+
+        let mut pending: Vec<(char, LinkManagerAction)> =
+            resp_actions.into_iter().map(|a| ('r', a)).collect();
+        let mut rounds = 0;
+        let mut received_response = None;
+
+        while !pending.is_empty() && rounds < 200 {
+            rounds += 1;
+            let mut next = Vec::new();
+
+            for (source, action) in pending.drain(..) {
+                let LinkManagerAction::SendPacket { raw, .. } = action else {
+                    continue;
+                };
+                let pkt = RawPacket::unpack(&raw).unwrap();
+                let target_actions = if source == 'r' {
+                    init_mgr.handle_local_delivery(
+                        pkt.destination_hash,
+                        &raw,
+                        pkt.packet_hash,
+                        rns_core::transport::types::InterfaceId(0),
+                        &mut rng,
+                    )
+                } else {
+                    resp_mgr.handle_local_delivery(
+                        pkt.destination_hash,
+                        &raw,
+                        pkt.packet_hash,
+                        rns_core::transport::types::InterfaceId(0),
+                        &mut rng,
+                    )
+                };
+
+                let target_source = if source == 'r' { 'i' } else { 'r' };
+                for target_action in &target_actions {
+                    match target_action {
+                        LinkManagerAction::ResponseReceived {
+                            request_id: rid,
+                            data,
+                            ..
+                        } => {
+                            received_response = Some((*rid, data.clone()));
+                        }
+                        LinkManagerAction::ResourceReceived { .. } => {
+                            panic!("response resources must complete as ResponseReceived")
+                        }
+                        LinkManagerAction::ResourceAcceptQuery { .. } => {
+                            panic!("response resources must bypass application acceptance")
+                        }
+                        _ => {}
+                    }
+                }
+                next.extend(target_actions.into_iter().map(|a| (target_source, a)));
+            }
+
+            pending = next;
+        }
+
+        let (received_request_id, received_data) = received_response.unwrap_or_else(|| {
+            panic!(
+                "large response resource did not complete as ResponseReceived after {} rounds",
+                rounds
+            )
+        });
+        assert_eq!(received_request_id, request_id);
+        assert_eq!(received_data, response_value);
+    }
+
+    #[test]
+    fn test_negotiated_mtu_response_uses_resource_before_global_mtu() {
+        let (mut init_mgr, mut resp_mgr, link_id) = setup_active_link();
+        let mut rng = OsRng;
+
+        init_mgr.set_link_mtu(&link_id, 300);
+        resp_mgr.set_link_mtu(&link_id, 300);
+
+        let payload = vec![0xAB; 350];
+        let response_value =
+            rns_core::msgpack::pack(&rns_core::msgpack::Value::Bin(payload));
+        resp_mgr.register_request_handler("/mtu", None, {
+            let response_value = response_value.clone();
+            move |_link_id, _path, _data, _remote| Some(response_value.clone())
+        });
+
+        let req_actions = init_mgr.send_request(&link_id, "/mtu", b"\xc0", &mut rng);
+        let req_raw = extract_any_send_packet(&req_actions);
+        let req_pkt = RawPacket::unpack(&req_raw).unwrap();
+        let resp_actions = resp_mgr.handle_local_delivery(
+            req_pkt.destination_hash,
+            &req_raw,
+            req_pkt.packet_hash,
+            rns_core::transport::types::InterfaceId(0),
+            &mut rng,
+        );
+
+        let mut has_resource_adv = false;
+        let mut direct_response_len = None;
+        for action in &resp_actions {
+            if let LinkManagerAction::SendPacket { raw, .. } = action {
+                let pkt = RawPacket::unpack(raw).unwrap();
+                has_resource_adv |= pkt.context == constants::CONTEXT_RESOURCE_ADV;
+                if pkt.context == constants::CONTEXT_RESPONSE {
+                    direct_response_len = Some(raw.len());
+                }
+            }
+        }
+
+        assert!(
+            has_resource_adv,
+            "responses larger than the negotiated link MTU should use resource fallback"
+        );
+        assert!(
+            direct_response_len.is_none(),
+            "sent direct response of {} bytes on a 300 byte negotiated MTU",
+            direct_response_len.unwrap_or_default()
+        );
+    }
+
+    #[test]
+    fn test_large_management_response_uses_resource_fallback() {
+        let (_init_mgr, mut resp_mgr, link_id) = setup_active_link();
+        let mut rng = OsRng;
+
+        let payload = vec![0xBC; 5000];
+        let response_value =
+            rns_core::msgpack::pack(&rns_core::msgpack::Value::Bin(payload));
+        let actions = resp_mgr.send_management_response(
+            &link_id,
+            &[0x55; 16],
+            &response_value,
+            &mut rng,
+        );
+
+        let mut has_resource_adv = false;
+        let mut has_direct_response = false;
+        for action in &actions {
+            if let LinkManagerAction::SendPacket { raw, .. } = action {
+                let pkt = RawPacket::unpack(raw).unwrap();
+                has_resource_adv |= pkt.context == constants::CONTEXT_RESOURCE_ADV;
+                has_direct_response |= pkt.context == constants::CONTEXT_RESPONSE;
+            }
+        }
+
+        assert!(
+            has_resource_adv,
+            "large management responses should advertise a response resource"
+        );
+        assert!(
+            !has_direct_response,
+            "large management responses should not use a direct CONTEXT_RESPONSE packet"
+        );
     }
 }

--- a/rns-net/src/common/link_manager.rs
+++ b/rns-net/src/common/link_manager.rs
@@ -3798,6 +3798,58 @@ mod tests {
     }
 
     #[test]
+    fn test_large_response_uses_resource_fallback() {
+        let (init_mgr, mut resp_mgr, link_id) = setup_active_link();
+        let mut rng = OsRng;
+
+        // Register handler on responder with payload that cannot fit a direct
+        // CONTEXT_RESPONSE packet.
+        let large_payload: Vec<u8> = (0..5000u32).map(|i| (i & 0xFF) as u8).collect();
+        resp_mgr.register_request_handler("/large", None, {
+            let large_payload = large_payload.clone();
+            move |_link_id, _path, _data, _remote| Some(large_payload.clone())
+        });
+
+        // Send request from initiator.
+        let req_actions = init_mgr.send_request(&link_id, "/large", b"\xc0", &mut rng);
+        assert!(!req_actions.is_empty());
+
+        // Deliver request to responder and inspect responder outbound packets.
+        let req_raw = extract_any_send_packet(&req_actions);
+        let req_pkt = RawPacket::unpack(&req_raw).unwrap();
+        let resp_actions = resp_mgr.handle_local_delivery(
+            req_pkt.destination_hash,
+            &req_raw,
+            req_pkt.packet_hash,
+            rns_core::transport::types::InterfaceId(0),
+            &mut rng,
+        );
+
+        let mut has_resource_adv = false;
+        let mut has_direct_response = false;
+        for action in &resp_actions {
+            if let LinkManagerAction::SendPacket { raw, .. } = action {
+                let pkt = RawPacket::unpack(raw).unwrap();
+                if pkt.context == constants::CONTEXT_RESOURCE_ADV {
+                    has_resource_adv = true;
+                }
+                if pkt.context == constants::CONTEXT_RESPONSE {
+                    has_direct_response = true;
+                }
+            }
+        }
+
+        assert!(
+            has_resource_adv,
+            "Large response should advertise a response resource"
+        );
+        assert!(
+            !has_direct_response,
+            "Large response should not use direct CONTEXT_RESPONSE packet"
+        );
+    }
+
+    #[test]
     fn test_send_channel_message_on_no_channel() {
         let mut mgr = LinkManager::new();
         let mut rng = OsRng;

--- a/rns-net/src/driver.rs
+++ b/rns-net/src/driver.rs
@@ -13774,6 +13774,48 @@ mod tests {
     }
 
     #[test]
+    fn link_manager_data_send_is_tracked_for_proofs() {
+        let mut driver = new_test_driver();
+        let (writer, _sent) = MockWriter::new();
+        driver
+            .interfaces
+            .insert(InterfaceId(1), make_entry(1, Box::new(writer), true));
+
+        let flags = PacketFlags {
+            header_type: constants::HEADER_1,
+            context_flag: constants::FLAG_UNSET,
+            transport_type: constants::TRANSPORT_BROADCAST,
+            destination_type: constants::DESTINATION_LINK,
+            packet_type: constants::PACKET_TYPE_DATA,
+        };
+        let packet = RawPacket::pack(
+            flags,
+            0,
+            &[0x77; 16],
+            None,
+            constants::CONTEXT_NONE,
+            b"track me",
+        )
+        .unwrap();
+        let packet_hash = packet.packet_hash;
+        let destination_hash = packet.destination_hash;
+
+        driver.dispatch_link_actions(vec![LinkManagerAction::SendPacket {
+            raw: packet.raw,
+            dest_type: constants::DESTINATION_LINK,
+            attached_interface: Some(InterfaceId(1)),
+        }]);
+
+        assert_eq!(
+            driver
+                .sent_packets
+                .get(&packet_hash)
+                .map(|(dest, _)| *dest),
+            Some(destination_hash)
+        );
+    }
+
+    #[test]
     fn inbound_proof_with_valid_signature_fires_callback() {
         // When the destination IS in known_destinations, the proof signature is verified
         let (tx, rx) = event::channel();

--- a/rns-net/src/driver.rs
+++ b/rns-net/src/driver.rs
@@ -78,6 +78,23 @@ const DEFAULT_MANAGEMENT_ANNOUNCE_INTERVAL_SECS: f64 = 300.0;
 const SEND_RETRY_BACKOFF_MIN: Duration = Duration::from_millis(25);
 const SEND_RETRY_BACKOFF_MAX: Duration = Duration::from_millis(1000);
 
+fn inject_transport_header(raw: &[u8], next_hop: &[u8; 16]) -> Vec<u8> {
+    if raw.len() < 18 {
+        return raw.to_vec();
+    }
+
+    let new_flags = (rns_core::constants::HEADER_2 << 6)
+        | (rns_core::constants::TRANSPORT_TRANSPORT << 4)
+        | (raw[0] & 0x0F);
+
+    let mut new_raw = Vec::with_capacity(raw.len() + 16);
+    new_raw.push(new_flags);
+    new_raw.push(raw[1]);
+    new_raw.extend_from_slice(next_hop);
+    new_raw.extend_from_slice(&raw[2..]);
+    new_raw
+}
+
 #[derive(Debug, Clone, Copy)]
 pub(crate) struct RuntimeConfigDefaults {
     pub(crate) tick_interval_ms: u64,
@@ -7239,10 +7256,45 @@ impl Driver {
         for action in actions {
             match action {
                 LinkManagerAction::SendPacket {
-                    raw,
+                    mut raw,
                     dest_type,
-                    attached_interface,
+                    mut attached_interface,
                 } => {
+                    if dest_type == rns_core::constants::DESTINATION_LINK
+                        && attached_interface.is_none()
+                    {
+                        if let Ok(packet) = RawPacket::unpack(&raw) {
+                            let link_id = packet.destination_hash;
+                            if let Some((iface, transport_id)) =
+                                self.link_manager.get_link_route_hint(&link_id)
+                            {
+                                attached_interface = Some(iface);
+                                if packet.flags.header_type == rns_core::constants::HEADER_1 {
+                                    if let Some(next_hop) = transport_id {
+                                        raw = inject_transport_header(&packet.raw, &next_hop);
+                                        log::debug!(
+                                            "Link SendPacket rewrite: link={:02x?} iface={} header=1->2 tid={:02x?}",
+                                            &link_id[..4],
+                                            iface.0,
+                                            &next_hop[..4]
+                                        );
+                                    } else {
+                                        log::debug!(
+                                            "Link SendPacket route: link={:02x?} iface={} header=1 (no transport_id)",
+                                            &link_id[..4],
+                                            iface.0
+                                        );
+                                    }
+                                }
+                            } else {
+                                log::debug!(
+                                    "Link SendPacket no route hint: link={:02x?}",
+                                    &link_id[..4]
+                                );
+                            }
+                        }
+                    }
+
                     // Route through the transport engine's outbound path
                     match RawPacket::unpack(&raw) {
                         Ok(packet) => {

--- a/rns-net/src/driver.rs
+++ b/rns-net/src/driver.rs
@@ -6395,19 +6395,55 @@ impl Driver {
         proof_data: &[u8],
         _raw_packet_hash: &[u8; 32],
     ) {
-        // Explicit proof format: [packet_hash:32][signature:64] = 96 bytes
-        if proof_data.len() < 96 {
-            log::debug!(
-                "Proof too short for explicit proof: {} bytes",
-                proof_data.len()
-            );
+        // Reticulum supports both proof formats:
+        // - explicit: [packet_hash:32][signature:64]
+        // - implicit: [signature:64], keyed by proof destination hash
+        let (tracked_hash, signature): ([u8; 32], &[u8]) = if proof_data.len() >= 96 {
+            let mut tracked_hash = [0u8; 32];
+            tracked_hash.copy_from_slice(&proof_data[..32]);
+            (tracked_hash, &proof_data[32..96])
+        } else if proof_data.len() == 64 {
+            let mut candidates = self
+                .sent_packets
+                .iter()
+                .filter_map(|(packet_hash, _)| {
+                    if packet_hash[..16] == dest_hash {
+                        Some(*packet_hash)
+                    } else {
+                        None
+                    }
+                })
+                .collect::<Vec<_>>();
+
+            if candidates.is_empty() {
+                log::debug!(
+                    "Implicit proof for unknown packet prefix {:02x?} on dest {:02x?}",
+                    &dest_hash[..4],
+                    &dest_hash[..4]
+                );
+                return;
+            }
+
+            // Multiple matches are extremely unlikely (16-byte truncated hash).
+            // Use the newest tracked packet for deterministic behavior.
+            if candidates.len() > 1 {
+                candidates.sort_by(|a, b| {
+                    let ta = self.sent_packets.get(a).map(|(_, t)| *t).unwrap_or_default();
+                    let tb = self.sent_packets.get(b).map(|(_, t)| *t).unwrap_or_default();
+                    tb.partial_cmp(&ta).unwrap_or(core::cmp::Ordering::Equal)
+                });
+                log::debug!(
+                    "Implicit proof matched {} candidates for prefix {:02x?}; using newest",
+                    candidates.len(),
+                    &dest_hash[..4]
+                );
+            }
+
+            (candidates[0], &proof_data[..64])
+        } else {
+            log::debug!("Unsupported proof length: {} bytes", proof_data.len());
             return;
-        }
-
-        let mut tracked_hash = [0u8; 32];
-        tracked_hash.copy_from_slice(&proof_data[..32]);
-
-        let signature = &proof_data[32..96];
+        };
 
         // Look up the tracked sent packet
         if let Some((tracked_dest, sent_time)) = self.sent_packets.remove(&tracked_hash) {
@@ -7298,6 +7334,12 @@ impl Driver {
                     // Route through the transport engine's outbound path
                     match RawPacket::unpack(&raw) {
                         Ok(packet) => {
+                            if packet.flags.packet_type == rns_core::constants::PACKET_TYPE_DATA {
+                                self.sent_packets.insert(
+                                    packet.packet_hash,
+                                    (packet.destination_hash, time::now()),
+                                );
+                            }
                             let transport_actions = self.engine.handle_outbound(
                                 &packet,
                                 dest_type,
@@ -13636,6 +13678,99 @@ mod tests {
 
         // on_proof should NOT have been called
         assert!(proofs.lock().unwrap().is_empty());
+    }
+
+    #[test]
+    fn inbound_implicit_proof_matches_truncated_destination() {
+        let (tx, rx) = event::channel();
+        let proofs = Arc::new(Mutex::new(Vec::new()));
+        let cbs = MockCallbacks {
+            announces: Arc::new(Mutex::new(Vec::new())),
+            paths: Arc::new(Mutex::new(Vec::new())),
+            deliveries: Arc::new(Mutex::new(Vec::new())),
+            iface_ups: Arc::new(Mutex::new(Vec::new())),
+            iface_downs: Arc::new(Mutex::new(Vec::new())),
+            link_established: Arc::new(Mutex::new(Vec::new())),
+            link_closed: Arc::new(Mutex::new(Vec::new())),
+            remote_identified: Arc::new(Mutex::new(Vec::new())),
+            resources_received: Arc::new(Mutex::new(Vec::new())),
+            resource_completed: Arc::new(Mutex::new(Vec::new())),
+            resource_failed: Arc::new(Mutex::new(Vec::new())),
+            channel_messages: Arc::new(Mutex::new(Vec::new())),
+            link_data: Arc::new(Mutex::new(Vec::new())),
+            responses: Arc::new(Mutex::new(Vec::new())),
+            proofs: proofs.clone(),
+            proof_requested: Arc::new(Mutex::new(Vec::new())),
+        };
+
+        let mut driver = Driver::new(
+            TransportConfig {
+                transport_enabled: false,
+                identity_hash: None,
+                prefer_shorter_path: false,
+                max_paths_per_destination: 1,
+                packet_hashlist_max_entries: rns_core::constants::HASHLIST_MAXSIZE,
+                max_discovery_pr_tags: rns_core::constants::MAX_PR_TAGS,
+                max_path_destinations: usize::MAX,
+                max_tunnel_destinations_total: usize::MAX,
+                destination_timeout_secs: rns_core::constants::DESTINATION_TIMEOUT,
+                announce_table_ttl_secs: rns_core::constants::ANNOUNCE_TABLE_TTL,
+                announce_table_max_bytes: rns_core::constants::ANNOUNCE_TABLE_MAX_BYTES,
+                announce_sig_cache_enabled: true,
+                announce_sig_cache_max_entries: rns_core::constants::ANNOUNCE_SIG_CACHE_MAXSIZE,
+                announce_sig_cache_ttl_secs: rns_core::constants::ANNOUNCE_SIG_CACHE_TTL,
+                announce_queue_max_entries: 256,
+                announce_queue_max_interfaces: 1024,
+            },
+            rx,
+            tx.clone(),
+            Box::new(cbs),
+        );
+        let info = make_interface_info(1);
+        driver.engine.register_interface(info);
+        let (writer, _sent) = MockWriter::new();
+        driver
+            .interfaces
+            .insert(InterfaceId(1), make_entry(1, Box::new(writer), true));
+
+        let tracked_hash = [0x3Cu8; 32];
+        let sent_time = time::now() - 0.25;
+        driver
+            .sent_packets
+            .insert(tracked_hash, ([0xEE; 16], sent_time));
+
+        let mut proof_dest = [0u8; 16];
+        proof_dest.copy_from_slice(&tracked_hash[..16]);
+        driver
+            .engine
+            .register_destination(proof_dest, constants::DESTINATION_SINGLE);
+
+        // Implicit proof is signature-only (64 bytes)
+        let proof_data = vec![0xAA; 64];
+        let flags = PacketFlags {
+            header_type: constants::HEADER_1,
+            context_flag: constants::FLAG_UNSET,
+            transport_type: constants::TRANSPORT_BROADCAST,
+            destination_type: constants::DESTINATION_SINGLE,
+            packet_type: constants::PACKET_TYPE_PROOF,
+        };
+        let packet =
+            RawPacket::pack(flags, 0, &proof_dest, None, constants::CONTEXT_NONE, &proof_data)
+                .unwrap();
+
+        tx.send(Event::Frame {
+            interface_id: InterfaceId(1),
+            data: packet.raw,
+        })
+        .unwrap();
+        tx.send(Event::Shutdown).unwrap();
+        driver.run();
+
+        let proof_list = proofs.lock().unwrap();
+        assert_eq!(proof_list.len(), 1);
+        assert_eq!(proof_list[0].0, DestHash([0xEE; 16]));
+        assert_eq!(proof_list[0].1, PacketHash(tracked_hash));
+        assert!(!driver.sent_packets.contains_key(&tracked_hash));
     }
 
     #[test]

--- a/rns-net/tests/e2e.rs
+++ b/rns-net/tests/e2e.rs
@@ -2667,6 +2667,57 @@ fn test_multiple_requests_same_link() {
     transport.shutdown();
 }
 
+#[test]
+fn test_request_response_large_payload_over_resource() {
+    let (
+        transport,
+        alice_node,
+        alice_rx,
+        bob_node,
+        _bob_rx,
+        _alice_id,
+        _bob_id,
+        _alice_dest,
+        _bob_dest,
+        link_id,
+    ) = setup_link();
+
+    // Force resource transfer with payload well above link MDU
+    let large: Vec<u8> = (0..16_811u32).map(|i| (i & 0xFF) as u8).collect();
+    bob_node
+        .register_request_handler("/large", None, {
+            let large = large.clone();
+            move |_link_id, _path, _data, _identity| Some(large.clone())
+        })
+        .unwrap();
+
+    std::thread::sleep(Duration::from_millis(200));
+
+    alice_node.send_request(link_id, "/large", b"x").unwrap();
+
+    let (resp_lid, _req_id, resp_data) =
+        wait_for_response(&alice_rx, Duration::from_secs(30))
+            .expect("Alice did not receive large response over resource transfer");
+    assert_eq!(resp_lid, link_id);
+
+    let resp_value = rns_core::msgpack::unpack_exact(&resp_data).unwrap();
+    let resp_bytes = match resp_value {
+        rns_core::msgpack::Value::Bin(b) => b,
+        _ => panic!("Expected msgpack Bin, got {:?}", resp_value),
+    };
+    assert_eq!(resp_bytes.len(), 16_811);
+    for i in 0..16_811u32 {
+        assert_eq!(resp_bytes[i as usize], (i & 0xFF) as u8);
+    }
+
+    alice_node.teardown_link(link_id).unwrap();
+    std::thread::sleep(Duration::from_millis(500));
+
+    alice_node.shutdown();
+    bob_node.shutdown();
+    transport.shutdown();
+}
+
 // ═══════════════════════════════════════════════════════════════════════════════
 // 10. Resource Transfer
 // ═══════════════════════════════════════════════════════════════════════════════


### PR DESCRIPTION
I had some problems with nomadnet-rs due some pages having larger than MTU sizes in multi-hop links.

The previous patch I sent I also reverted, because it was just because of a problem in multi-hop path that worked as a workaround. 

Btw I will be publishing nomadnet-rs at https://github.com/TeskesLab/nomadnet-rs/ (its currently private), just waiting to get everything working (which seens with this change).

After this changes multi-hop communication should work fine with the python implementation. 

Sorry for sending the patches without knowing for sure it was working. At least now the `nomad-serve` program I did works fine usign MeshChatX.

Edit: Forgot to mention, this supports resource send, which is required for larger-than-mtu transfers (like files or nomadnet)