### PR TITLE
Release Reticulum 1.2 utility ports

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1951,7 +1951,7 @@ dependencies = [
 
 [[package]]
 name = "rns-cli"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "anyhow",
  "bincode",
@@ -1972,7 +1972,7 @@ dependencies = [
 
 [[package]]
 name = "rns-core"
-version = "0.1.10"
+version = "0.1.11"
 dependencies = [
  "criterion",
  "log",
@@ -1982,7 +1982,7 @@ dependencies = [
 
 [[package]]
 name = "rns-crypto"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "aes",
  "cbc",
@@ -1996,7 +1996,7 @@ dependencies = [
 
 [[package]]
 name = "rns-ctl"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "env_logger 0.11.8",
  "libc",
@@ -2027,7 +2027,7 @@ dependencies = [
 
 [[package]]
 name = "rns-hooks"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "criterion",
  "libloading",
@@ -2039,18 +2039,18 @@ dependencies = [
 
 [[package]]
 name = "rns-hooks-abi"
-version = "0.1.2"
+version = "0.1.3"
 
 [[package]]
 name = "rns-hooks-sdk"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "rns-hooks-abi",
 ]
 
 [[package]]
 name = "rns-net"
-version = "0.5.7"
+version = "0.5.8"
 dependencies = [
  "bincode",
  "bzip2",
@@ -2072,7 +2072,7 @@ dependencies = [
 
 [[package]]
 name = "rns-sentinel-hook"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "rns-hooks-abi",
  "rns-hooks-sdk",
@@ -2080,7 +2080,7 @@ dependencies = [
 
 [[package]]
 name = "rns-server"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "env_logger 0.11.8",
  "libc",
@@ -2094,7 +2094,7 @@ dependencies = [
 
 [[package]]
 name = "rns-stats-hook"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "rns-hooks-abi",
  "rns-hooks-sdk",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,17 +5,17 @@ exclude = ["rns-esp32"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.5"
+version = "0.1.6"
 edition = "2021"
 license-file = "LICENSE"
 repository = "https://github.com/lelloman/rns-rs"
 authors = ["rns-rs contributors"]
 
 [workspace.dependencies]
-rns-crypto = { version = "0.1.5", path = "rns-crypto" }
-rns-core = { version = "0.1.10", path = "rns-core" }
-rns-net = { version = "0.5.7", path = "rns-net" }
-rns-hooks = { version = "0.1.5", path = "rns-hooks", default-features = false }
+rns-crypto = { version = "0.1.6", path = "rns-crypto" }
+rns-core = { version = "0.1.11", path = "rns-core" }
+rns-net = { version = "0.5.8", path = "rns-net" }
+rns-hooks = { version = "0.1.6", path = "rns-hooks", default-features = false }
 
 # Compile crypto crate with optimizations even in debug/test builds.
 # Helps curve25519-dalek performance in debug mode.

--- a/rns-cli/Cargo.toml
+++ b/rns-cli/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rns-cli"
 description = "CLI tools for the Reticulum Network Stack"
-version = "0.2.2"
+version = "0.2.3"
 edition.workspace = true
 license-file.workspace = true
 repository.workspace = true
@@ -18,7 +18,7 @@ rns-hooks-builtin = ["rns-net/rns-hooks-builtin"]
 rns-net.workspace = true
 rns-core.workspace = true
 rns-crypto.workspace = true
-rns-hooks-abi = { version = "0.1.2", path = "../rns-hooks/sdk/rns-hooks-abi", optional = true }
+rns-hooks-abi = { version = "0.1.3", path = "../rns-hooks/sdk/rns-hooks-abi", optional = true }
 log = "0.4"
 env_logger = "0.10"
 libc = "0.2"
@@ -31,8 +31,8 @@ tikv-jemallocator = "0.6"
 [build-dependencies]
 anyhow = "1"
 serde_json = "1"
-rns-stats-hook = { version = "0.1.1", path = "../rns-stats-hook", optional = true }
-rns-sentinel-hook = { version = "0.1.1", path = "../rns-sentinel-hook", optional = true }
+rns-stats-hook = { version = "0.1.2", path = "../rns-stats-hook", optional = true }
+rns-sentinel-hook = { version = "0.1.2", path = "../rns-sentinel-hook", optional = true }
 
 [dev-dependencies]
 tempfile = "3"

--- a/rns-cli/build.rs
+++ b/rns-cli/build.rs
@@ -2,7 +2,7 @@ use std::env;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
-#[path = "../build/common.rs"]
+#[path = "build_common.rs"]
 mod build_common;
 
 fn main() {

--- a/rns-cli/build_common.rs
+++ b/rns-cli/build_common.rs
@@ -1,0 +1,29 @@
+use std::process::Command;
+
+pub fn emit_git_rerun_inputs() {
+    println!("cargo:rerun-if-changed=../.git/HEAD");
+    println!("cargo:rerun-if-changed=../.git/refs");
+}
+
+pub fn emit_full_version() {
+    let pkg_version = env!("CARGO_PKG_VERSION");
+    let parts: Vec<&str> = pkg_version.split('.').collect();
+    let major = parts.first().unwrap_or(&"0");
+    let minor = parts.get(1).unwrap_or(&"0");
+
+    let commit_count = git_stdout(["rev-list", "--count", "HEAD"]).unwrap_or_else(|| "0".into());
+    let commit_hash =
+        git_stdout(["rev-parse", "--short", "HEAD"]).unwrap_or_else(|| "unknown".into());
+
+    let version = format!("{}.{}.{}-{}", major, minor, commit_count, commit_hash);
+    println!("cargo:rustc-env=FULL_VERSION={}", version);
+}
+
+fn git_stdout<const N: usize>(args: [&str; N]) -> Option<String> {
+    Command::new("git")
+        .args(args)
+        .output()
+        .ok()
+        .and_then(|o| String::from_utf8(o.stdout).ok())
+        .map(|s| s.trim().to_string())
+}

--- a/rns-core/Cargo.toml
+++ b/rns-core/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rns-core"
 description = "Wire protocol, transport routing, and link/resource engine for the Reticulum Network Stack"
-version = "0.1.10"
+version = "0.1.11"
 edition.workspace = true
 license-file.workspace = true
 repository.workspace = true

--- a/rns-ctl/Cargo.toml
+++ b/rns-ctl/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rns-ctl"
 description = "Reticulum Network Stack control tool"
-version = "0.2.4"
+version = "0.2.5"
 edition.workspace = true
 license-file.workspace = true
 repository.workspace = true
@@ -30,6 +30,6 @@ rustls-pemfile = { version = "2", optional = true }
 
 [dev-dependencies]
 rcgen = { version = "0.13", default-features = false, features = ["aws_lc_rs", "pem"] }
-rns-hooks-crate = { package = "rns-hooks", version = "0.1.5", path = "../rns-hooks", default-features = false }
+rns-hooks-crate = { package = "rns-hooks", version = "0.1.6", path = "../rns-hooks", default-features = false }
 rustls = "0.23"
 rustls-pemfile = "2"

--- a/rns-hooks/Cargo.toml
+++ b/rns-hooks/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rns-hooks"
 description = "Programmable hook system for the Reticulum Network Stack"
-version = "0.1.5"
+version = "0.1.6"
 edition.workspace = true
 license-file.workspace = true
 repository.workspace = true
@@ -16,7 +16,7 @@ native = ["dep:libloading"]
 wasmtime = { version = "29", optional = true }
 libloading = { version = "0.8", optional = true }
 log = "0.4"
-rns-hooks-abi = { version = "0.1.2", path = "sdk/rns-hooks-abi" }
+rns-hooks-abi = { version = "0.1.3", path = "sdk/rns-hooks-abi" }
 
 [dev-dependencies]
 criterion = { version = "0.5", features = ["html_reports"] }

--- a/rns-hooks/sdk/rns-hooks-abi/Cargo.toml
+++ b/rns-hooks/sdk/rns-hooks-abi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rns-hooks-abi"
-version = "0.1.2"
+version = "0.1.3"
 edition = "2021"
 description = "Shared ABI definitions for rns-hooks host and SDK"
 license = "MIT"

--- a/rns-hooks/sdk/rns-hooks-sdk/Cargo.toml
+++ b/rns-hooks/sdk/rns-hooks-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rns-hooks-sdk"
-version = "0.1.2"
+version = "0.1.3"
 edition = "2021"
 description = "Guest-side SDK for writing rns-hooks WASM programs"
 license = "MIT"
@@ -11,6 +11,6 @@ default = []
 alloc = []
 
 [dependencies]
-rns-hooks-abi = { version = "0.1.2", path = "../rns-hooks-abi" }
+rns-hooks-abi = { version = "0.1.3", path = "../rns-hooks-abi" }
 
 [lib]

--- a/rns-net/Cargo.toml
+++ b/rns-net/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rns-net"
 description = "Network interfaces and node driver for the Reticulum Network Stack"
-version = "0.5.7"
+version = "0.5.8"
 edition.workspace = true
 license-file.workspace = true
 repository.workspace = true
@@ -27,7 +27,7 @@ iface-i2p = []
 
 [dependencies]
 rns-core.workspace = true
-rns-hooks-crate = { package = "rns-hooks", version = "0.1.5", path = "../rns-hooks", optional = true, default-features = false }
+rns-hooks-crate = { package = "rns-hooks", version = "0.1.6", path = "../rns-hooks", optional = true, default-features = false }
 rns-crypto.workspace = true
 log = "0.4"
 rayon = "1"

--- a/rns-sentinel-hook/Cargo.toml
+++ b/rns-sentinel-hook/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rns-sentinel-hook"
 description = "WASM sentinel hook used by rns-sentineld"
-version = "0.1.1"
+version = "0.1.2"
 edition.workspace = true
 license-file.workspace = true
 repository.workspace = true
@@ -11,5 +11,5 @@ authors.workspace = true
 crate-type = ["cdylib"]
 
 [dependencies]
-rns-hooks-sdk = { version = "0.1.2", path = "../rns-hooks/sdk/rns-hooks-sdk" }
-rns-hooks-abi = { version = "0.1.2", path = "../rns-hooks/sdk/rns-hooks-abi" }
+rns-hooks-sdk = { version = "0.1.3", path = "../rns-hooks/sdk/rns-hooks-sdk" }
+rns-hooks-abi = { version = "0.1.3", path = "../rns-hooks/sdk/rns-hooks-abi" }

--- a/rns-server/Cargo.toml
+++ b/rns-server/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rns-server"
 description = "Batteries-included Reticulum node server"
-version = "0.1.1"
+version = "0.1.2"
 edition.workspace = true
 license-file.workspace = true
 repository.workspace = true
@@ -15,9 +15,9 @@ rns-hooks-native = ["rns-cli/rns-hooks-native", "rns-net/rns-hooks-native", "rns
 rns-hooks-builtin = ["rns-cli/rns-hooks-builtin", "rns-net/rns-hooks-builtin", "rns-ctl/rns-hooks-builtin"]
 
 [dependencies]
-rns-cli = { version = "0.2.2", path = "../rns-cli" }
+rns-cli = { version = "0.2.3", path = "../rns-cli" }
 rns-net.workspace = true
-rns-ctl = { version = "0.2.3", path = "../rns-ctl" }
+rns-ctl = { version = "0.2.5", path = "../rns-ctl" }
 env_logger = "0.11"
 libc = "0.2"
 log = "0.4"

--- a/rns-server/build.rs
+++ b/rns-server/build.rs
@@ -1,4 +1,4 @@
-#[path = "../build/common.rs"]
+#[path = "build_common.rs"]
 mod build_common;
 
 fn main() {

--- a/rns-server/build_common.rs
+++ b/rns-server/build_common.rs
@@ -1,0 +1,29 @@
+use std::process::Command;
+
+pub fn emit_git_rerun_inputs() {
+    println!("cargo:rerun-if-changed=../.git/HEAD");
+    println!("cargo:rerun-if-changed=../.git/refs");
+}
+
+pub fn emit_full_version() {
+    let pkg_version = env!("CARGO_PKG_VERSION");
+    let parts: Vec<&str> = pkg_version.split('.').collect();
+    let major = parts.first().unwrap_or(&"0");
+    let minor = parts.get(1).unwrap_or(&"0");
+
+    let commit_count = git_stdout(["rev-list", "--count", "HEAD"]).unwrap_or_else(|| "0".into());
+    let commit_hash =
+        git_stdout(["rev-parse", "--short", "HEAD"]).unwrap_or_else(|| "unknown".into());
+
+    let version = format!("{}.{}.{}-{}", major, minor, commit_count, commit_hash);
+    println!("cargo:rustc-env=FULL_VERSION={}", version);
+}
+
+fn git_stdout<const N: usize>(args: [&str; N]) -> Option<String> {
+    Command::new("git")
+        .args(args)
+        .output()
+        .ok()
+        .and_then(|o| String::from_utf8(o.stdout).ok())
+        .map(|s| s.trim().to_string())
+}

--- a/rns-stats-hook/Cargo.toml
+++ b/rns-stats-hook/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rns-stats-hook"
 description = "WASM stats hook used by rns-statsd"
-version = "0.1.1"
+version = "0.1.2"
 edition.workspace = true
 license-file.workspace = true
 repository.workspace = true
@@ -11,6 +11,6 @@ authors.workspace = true
 crate-type = ["cdylib"]
 
 [dependencies]
-rns-hooks-sdk = { version = "0.1.1", path = "../rns-hooks/sdk/rns-hooks-sdk" }
-rns-hooks-abi = { version = "0.1.1", path = "../rns-hooks/sdk/rns-hooks-abi" }
+rns-hooks-sdk = { version = "0.1.3", path = "../rns-hooks/sdk/rns-hooks-sdk" }
+rns-hooks-abi = { version = "0.1.3", path = "../rns-hooks/sdk/rns-hooks-abi" }
 sha2 = { version = "0.10", default-features = false }


### PR DESCRIPTION
Publishes the Reticulum 1.2 utility port release set to crates.io and records the version bumps used for the published artifacts.\n\nPublished crates:\n- rns-hooks-abi 0.1.3\n- rns-hooks-sdk 0.1.3\n- rns-crypto 0.1.6\n- rns-core 0.1.11\n- rns-hooks 0.1.6\n- rns-stats-hook 0.1.2\n- rns-sentinel-hook 0.1.2\n- rns-net 0.5.8\n- rns-cli 0.2.3\n- rns-ctl 0.2.5\n- rns-server 0.1.2\n- rns-git 0.1.0\n\nValidation run before publishing:\n- cargo check --workspace\n- cargo test --workspace\n- cargo publish --dry-run for each published crate in dependency order\n\nDirect master push is blocked by repository rules, so this PR carries the release-state commit that the pushed annotated release tags point to.