### PR TITLE
changed info print to debug print so that announcements aren't spammed into the output

### DIFF
--- a/rns-net/src/driver/dispatch.rs
+++ b/rns-net/src/driver/dispatch.rs
@@ -694,7 +694,7 @@ impl Driver {
                         snr: rx.snr,
                     };
                     self.upsert_known_destination(destination_hash, announced.clone());
-                    log::info!(
+                    log::debug!(
                         "Announce:validated dest={:02x}{:02x}{:02x}{:02x}.. hops={}",
                         destination_hash[0],
                         destination_hash[1],


### PR DESCRIPTION
Without this change INFO gets spammed relentlessly making debugging much more annoying, you can disable logging for a specific crate if you really need to but it just doesn't make sense to do an info print for every single announcement you receive as it's just not that important most of the time, you can change the logging to DEBUG if you really need that information.

<img width="782" height="636" alt="Screenshot_20260708_081126" src="https://github.com/user-attachments/assets/82a5d660-ef14-4822-8d8d-7f58c16d0df3" />
