### PR TITLE
Updating `rns-crypto` dependency and `f64` operation usages to support `no_std`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2013,6 +2013,7 @@ name = "rns-core"
 version = "0.1.16"
 dependencies = [
  "criterion",
+ "libm",
  "log",
  "rns-crypto",
  "serde_json",

--- a/rns-core/Cargo.toml
+++ b/rns-core/Cargo.toml
@@ -10,11 +10,12 @@ authors.workspace = true
 
 [features]
 default = ["std"]
-std = []
+std = ["rns-crypto/std"]
 
 [dependencies]
-rns-crypto.workspace = true
+rns-crypto = { path = "../rns-crypto", default_features = false }
 log = "0.4"
+libm = "0.2"
 
 [dev-dependencies]
 criterion = { version = "0.5", features = ["html_reports"] }

--- a/rns-core/src/channel/mod.rs
+++ b/rns-core/src/channel/mod.rs
@@ -229,7 +229,7 @@ impl Channel {
     ///
     /// Formula: `1.5^(tries-1) * max(rtt*2.5, 0.025) * (tx_ring.len() + 1.5)`
     pub fn get_packet_timeout(&self, tries: u8) -> f64 {
-        let base = 1.5_f64.powi((tries as i32) - 1);
+        let base = libm::pow(1.5_f64, ((tries as i32) - 1) as f64);
         let rtt_factor = (self.rtt * 2.5).max(0.025);
         let ring_factor = (self.tx_ring.len() as f64) + 1.5;
         base * rtt_factor * ring_factor

--- a/rns-core/src/transport/types.rs
+++ b/rns-core/src/transport/types.rs
@@ -64,7 +64,7 @@ fn lora_airtime_secs(
     }
 
     let sf = spreading_factor as f64;
-    let symbol_time = 2f64.powi(spreading_factor as i32) / bandwidth as f64;
+    let symbol_time = libm::pow(2f64, (spreading_factor as i32) as f64) / bandwidth as f64;
     let low_data_rate_optimize = spreading_factor >= 11 && bandwidth <= 125_000;
     let de = if low_data_rate_optimize { 1.0 } else { 0.0 };
     let ih = if explicit_header { 0.0 } else { 1.0 };
@@ -75,7 +75,7 @@ fn lora_airtime_secs(
     }
 
     let numerator = 8.0 * payload_len as f64 - 4.0 * sf + 28.0 + 16.0 * crc - 20.0 * ih;
-    let payload_symbols = 8.0 + (numerator / denominator).ceil().max(0.0) * coding_rate as f64;
+    let payload_symbols = 8.0 + libm::ceil(numerator / denominator).max(0.0) * coding_rate as f64;
     let preamble_time = (preamble_symbols as f64 + 4.25) * symbol_time;
     let payload_time = payload_symbols * symbol_time;
     preamble_time + payload_time


### PR DESCRIPTION
This PR is to resolve issue #111. It updates the `rns-crypto` dependency in `rns-core` to support `default_features = false` as before it depended on it with `std`. I left `libm` in as a dependency regardless of feature to simplify things rather than adding conditionals for the operations.