### PR TITLE
Fix Link send backpressure and expose per-link backlog

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1379,6 +1379,7 @@ checksum = "9a31d2a3fbaaeb2af2368bbdd904aa8e812d3c04a1ee10d3171f52d556e5d0a3"
 dependencies = [
  "futures-channel",
  "futures-core",
+ "futures-executor",
  "futures-io",
  "futures-sink",
  "futures-task",
@@ -1400,6 +1401,17 @@ name = "futures-core"
 version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92d699e522242e69e3003b94ecc1f960f3a5e015aa7c5d7486e65ad01dd94f5e"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "031b47cf1a3c6cc8bc2fc76cd437f521619387907d469316e7c0bc278f1f5432"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
 
 [[package]]
 name = "futures-io"
@@ -2532,6 +2544,7 @@ dependencies = [
  "criterion",
  "ctrlc",
  "env_logger",
+ "futures",
  "libc",
  "log",
  "polling",

--- a/docs/issue152-reproduction.md
+++ b/docs/issue152-reproduction.md
@@ -1,0 +1,75 @@
+# Issue #152: Link transmission completion
+
+Both APIs report successful transmission only when the interface writer has
+written the complete frame to its underlying transport. Neither promises
+remote reception or acknowledgement.
+
+```rust,ignore
+// Wait for outbound capacity, then wait for the actual write.
+node.send_on_link(link_id, payload, context).await?;
+
+// Do not wait for capacity. QueueFull means nothing was admitted.
+let receipt = node.try_send_on_link(link_id, payload, context)?;
+receipt.await?; // Exactly the same transmission result as send_on_link().
+```
+
+The futures work with any executor. Synchronous callers can use
+`node.try_send_on_link(...)?.wait()?`; do not block from driver callbacks.
+Migrating the old synchronous `send_on_link()` requires awaiting it or using
+the receipt's blocking `wait()`. Merely obtaining a receipt is admission, not
+transmission success. The existing `try_send_link_datagram()` remains an
+explicitly admission-only, best-effort API for datagram users such as rntun.
+
+The configured driver event capacity also bounds outstanding confirmed Link
+sends across driver events, pending interface frames, and writes in progress.
+The async API waits for admission; the try API returns QueueFull immediately.
+The driver retains accepted frames when a writer queue is full, preserving
+their per-interface order and continuing to process other events. Writer
+capacity notifications wake pending work. Completion releases admission space.
+
+Cancellation before admission sends nothing. Dropping an admitted send's
+future or receipt does not cancel it. Shutdown resolves pending receipts with
+an error. A write error may follow a partial transmission, so callers must not
+assume arbitrary errors are safe to retry. Routing/policy rejection and invalid
+Links also produce errors instead of successful receipts.
+
+## Regression tests
+
+```sh
+cargo test -p rns-net --test e2e issue152 -- --nocapture
+```
+
+Two Rust RnsNodes establish an encrypted Link over real loopback TCP. Eight
+paced packets verify delivery and payload integrity. A test-only wrapper then
+pauses the sender's concrete writer while 4,096 numbered 256-byte payloads
+(1 MiB) are admitted. Neither API may complete any send while the writer is
+paused. After release, every payload and a final marker must arrive, and all
+send completions must succeed. Both tests use the default 256-frame writer
+queue; one exercises async sends and the other the try/receipt API.
+
+The wrapper injects no packet loss and paces writes at 2 ms per frame. Both
+nodes have 8,192-event capacity so the whole test burst can be admitted and
+receiver ingress limits do not obscure the sender regression. Separate unit
+tests exercise full admission capacity, async wakeups, cancellation, writer
+flush/error handling, and shutdown. KISS/RNode tests verify that confirmed
+sends wait for flow-control readiness before completing.
+
+## Original reproduction (2026-09-08)
+
+Before the fix, the old synchronous API reported success for every send:
+
+| Sender writer queue | Successful send calls | Received burst packets | End marker |
+| --- | --- | --- | --- |
+| 256 (default) | 4,096 | 257 | Received |
+| 4,096 (control) | 4,096 | 4,096, intact and in order | Received |
+
+The default cutoff reproduced repeatedly: one packet was held by the concrete
+writer and 256 remained queued. `WouldBlock` discarded the rejected packet;
+subsequent packets were discarded during driver backoff. Increasing the queue
+was a diagnostic control, not the fix. With default receiver ingress limits,
+the control also experienced downstream loss, which is why the test isolates
+sender egress from receiver capacity.
+
+This demonstrates a Rust sender mechanism consistent with #152. It does not
+recreate the reporter's exact Python RNS 1.5.2 shared-instance topology or add
+reliable network delivery to raw Link packets.

--- a/docs/issue152-reproduction.md
+++ b/docs/issue152-reproduction.md
@@ -33,6 +33,25 @@ an error. A write error may follow a partial transmission, so callers must not
 assume arbitrary errors are safe to retry. Routing/policy rejection and invalid
 Links also produce errors instead of successful receipts.
 
+## Per-link send backlog
+
+`node.links()` includes two local send counters on every `LinkInfoEntry`:
+
+- `pending_send_packets`: admitted confirmed sends that have not finished
+  writing, including driver backlog, interface queues, and writes in progress.
+- `waiting_send_packets`: polled async sends waiting for admission capacity
+  (either the outstanding-send budget or the driver event queue).
+
+`node.query_link(link_id)?` returns `Some(LinkInfoEntry)` with the same fields,
+or `None` for an unknown link. The controller's link list exposes both counters
+as well. These are snapshots, not reservations or remote acknowledgement counts.
+They cover `send_on_link` and `try_send_on_link`; Channel counters remain
+separate, and the legacy admission-only datagram API is not included.
+
+Unpolled futures are not counted. Cancelling a send before admission removes
+its waiting count; dropping an admitted receipt does not remove its pending
+count. Completion, failure, and shutdown clear the corresponding counts.
+
 ## Regression tests
 
 ```sh
@@ -47,9 +66,11 @@ paused. After release, every payload and a final marker must arrive, and all
 send completions must succeed. Both tests use the default 256-frame writer
 queue; one exercises async sends and the other the try/receipt API.
 
-The wrapper injects no packet loss and paces writes at 2 ms per frame. Both
-nodes have 8,192-event capacity so the whole test burst can be admitted and
-receiver ingress limits do not obscure the sender regression. Separate unit
+The wrapper injects no packet loss and paces writes at 2 ms per frame. The
+sender has 4,096-event capacity, exactly filled by the burst, and the receiver
+has 8,192-event capacity to isolate sender egress from receiver ingress limits.
+The paused-writer tests also check the single-link/list snapshots and a further
+async send waiting for capacity, including its cancellation. Separate unit
 tests exercise full admission capacity, async wakeups, cancellation, writer
 flush/error handling, and shutdown. KISS/RNode tests verify that confirmed
 sends wait for flow-control readiness before completing.

--- a/docs/issue152-reproduction.md
+++ b/docs/issue152-reproduction.md
@@ -1,7 +1,7 @@
-# Issue #152: Link transmission completion
+# Issue #152: local transmission completion
 
-Both APIs report successful transmission only when the interface writer has
-written the complete frame to its underlying transport. Neither promises
+The async/try API pairs report successful transmission only when the selected
+interface writers have written the complete frame to their underlying transports. Neither promises
 remote reception or acknowledgement.
 
 ```rust,ignore
@@ -11,6 +11,14 @@ node.send_on_link(link_id, payload, context).await?;
 // Do not wait for capacity. QueueFull means nothing was admitted.
 let receipt = node.try_send_on_link(link_id, payload, context)?;
 receipt.await?; // Exactly the same transmission result as send_on_link().
+
+let hash = node.send_packet(&destination, &data).await?;
+let receipt = node.try_send_packet(&destination, &data)?;
+let hash_for_proof_tracking = receipt.packet_hash();
+let same_hash_after_transmission = receipt.await?;
+
+node.announce(&destination, &identity, app_data).await?;
+node.try_announce(&destination, &identity, app_data)?.await?;
 ```
 
 The futures work with any executor. Synchronous callers can use
@@ -20,8 +28,25 @@ the receipt's blocking `wait()`. Merely obtaining a receipt is admission, not
 transmission success. The existing `try_send_link_datagram()` remains an
 explicitly admission-only, best-effort API for datagram users such as rntun.
 
-The configured driver event capacity also bounds outstanding confirmed Link
-sends across driver events, pending interface frames, and writes in progress.
+`send_packet` and `announce` are now async too. Their old submission-only
+behavior is explicitly named `send_packet_queued` and `announce_queued` for
+callers that intentionally need best-effort queuing. These compatibility
+methods do not confirm transmission. Synchronous callers needing confirmation
+can use the `try_*` receipt's `wait()` (never from a driver callback).
+
+Packet and announcement success means every selected local interface writer
+completed its write. An error is returned only after all selected writes have
+settled; it may mean partial transmission across interfaces. No eligible route
+returns `TransmissionError::NoRoute`, not success. This does not wait for remote
+delivery, proofs, or announcement relays. Original hops-zero announcements keep
+their normal routing policy; relay bandwidth throttling is unchanged. Shared
+client replay state is stored with the admitted announcement, so queue rejection
+or cancellation before admission cannot update replay state.
+
+The configured driver event capacity bounds outstanding confirmed Link,
+packet, and announcement sends together across driver events, pending interface
+frames, and writes in progress. Broadcast fanout holds one admission slot until
+all selected writes settle. Packet/announcement sends do not affect Link counters.
 The async API waits for admission; the try API returns QueueFull immediately.
 The driver retains accepted frames when a writer queue is full, preserving
 their per-interface order and continuing to process other events. Writer

--- a/rns-cli/src/rncp.rs
+++ b/rns-cli/src/rncp.rs
@@ -376,7 +376,7 @@ fn listen(
     loop {
         if let Some(period) = options.announce {
             if !announced || period > 0 && last_announce.elapsed() >= Duration::from_secs(period) {
-                node.announce(&destination, identity, None)?;
+                node.announce_queued(&destination, identity, None)?;
                 announced = true;
                 last_announce = Instant::now();
             }

--- a/rns-cli/src/rnsh.rs
+++ b/rns-cli/src/rnsh.rs
@@ -1901,7 +1901,7 @@ fn listen(opts: CliOptions) -> Result<(), RnshError> {
             let due = period == 0 && !announced_once
                 || period > 0 && last_announce.elapsed() >= Duration::from_secs(period);
             if due {
-                node.announce(&dest, &identity, None)?;
+                node.announce_queued(&dest, &identity, None)?;
                 last_announce = Instant::now();
                 announced_once = true;
             }

--- a/rns-cli/src/rnx.rs
+++ b/rns-cli/src/rnx.rs
@@ -306,7 +306,7 @@ fn listen(
         eprintln!("warning: accepting unauthenticated remote commands");
     }
     if !options.no_announce {
-        node.announce(&destination, identity, None)?;
+        node.announce_queued(&destination, identity, None)?;
     }
     eprintln!("rnx listening on {}", prettyhexrep(&destination.hash.0));
 

--- a/rns-core/src/transport/tests.rs
+++ b/rns-core/src/transport/tests.rs
@@ -1089,6 +1089,29 @@ fn test_gate_retransmit_actions_expands_broadcast_to_matching_interfaces() {
 }
 
 #[test]
+fn test_tick_short_announce_ttl_allows_only_unexpired_retransmits() {
+    for (now, should_relay) in [(100.025, true), (100.075, false)] {
+        let mut config = make_config(true);
+        config.announce_table_ttl_secs = 0.05;
+        let mut engine = TransportEngine::new(config);
+        engine.register_interface(make_interface(1, constants::MODE_FULL));
+        let dest = [0x63; 16];
+        engine.register_destination(dest, constants::DESTINATION_SINGLE);
+        let mut entry = make_announce_entry(dest, 100.0, 8);
+        entry.retransmit_timeout = 100.01;
+        assert!(engine.insert_announce_entry(dest, entry, 100.0));
+
+        let mut rng = rns_crypto::FixedRng::new(&[0x11; 32]);
+        let actions = engine.tick(now, &mut rng);
+        let relayed = actions
+            .iter()
+            .any(|action| matches!(action, TransportAction::SendOnInterface { .. }));
+        assert_eq!(relayed, should_relay, "tick at {now}");
+        assert_eq!(engine.announce_table().contains_key(&dest), should_relay);
+    }
+}
+
+#[test]
 fn test_tick_culls_expired_announce_entries() {
     let mut config = make_config(true);
     config.announce_table_ttl_secs = 10.0;

--- a/rns-ctl/src/api.rs
+++ b/rns-ctl/src/api.rs
@@ -565,6 +565,8 @@ fn handle_links(node: &NodeHandle) -> HttpResponse {
                         "channel_window": l.channel_window,
                         "channel_outstanding": l.channel_outstanding,
                         "pending_channel_packets": l.pending_channel_packets,
+                        "pending_send_packets": l.pending_send_packets,
+                        "waiting_send_packets": l.waiting_send_packets,
                         "channel_send_ok": l.channel_send_ok,
                         "channel_send_not_ready": l.channel_send_not_ready,
                         "channel_send_too_big": l.channel_send_too_big,

--- a/rns-ctl/src/api.rs
+++ b/rns-ctl/src/api.rs
@@ -1002,10 +1002,28 @@ fn handle_post_link_send(req: &HttpRequest, node: &NodeHandle) -> HttpResponse {
     };
     let context = body["context"].as_u64().unwrap_or(0) as u8;
 
-    with_active_node(node, |n| match n.send_on_link(link_id, data, context) {
+    // Release the node handle before waiting for a slow interface, so other
+    // requests can still query, drain, or shut down the node.
+    let receipt = {
+        let guard = lock_node_handle(node);
+        let Some(n) = guard.as_ref() else {
+            return HttpResponse::internal_error("Node is shutting down");
+        };
+        match n.try_send_on_link(link_id, data, context) {
+            Ok(receipt) => receipt,
+            Err(rns_net::LinkSendError::QueueFull) => {
+                return HttpResponse::conflict("Outbound queue is full");
+            }
+            Err(_) => return HttpResponse::internal_error("Send on link failed"),
+        }
+    };
+    match receipt.wait() {
         Ok(()) => HttpResponse::ok(json!({"status": "sent"})),
+        Err(rns_net::LinkSendError::Draining) => {
+            HttpResponse::conflict("Node is draining and not accepting new work")
+        }
         Err(_) => HttpResponse::internal_error("Send on link failed"),
-    })
+    }
 }
 
 fn handle_post_link_close(req: &HttpRequest, node: &NodeHandle) -> HttpResponse {

--- a/rns-ctl/src/api.rs
+++ b/rns-ctl/src/api.rs
@@ -897,7 +897,7 @@ fn handle_post_announce(req: &HttpRequest, node: &NodeHandle, state: &SharedStat
     };
 
     with_active_node(node, |n| {
-        match n.announce(&dest, &identity, app_data.as_deref()) {
+        match n.announce_queued(&dest, &identity, app_data.as_deref()) {
             Ok(()) => HttpResponse::ok(json!({"status": "announced", "dest_hash": dh_str})),
             Err(_) => HttpResponse::internal_error("Announce failed"),
         }
@@ -944,7 +944,7 @@ fn handle_post_send(req: &HttpRequest, node: &NodeHandle, state: &SharedState) -
         ));
     }
 
-    with_active_node(node, |n| match n.send_packet(&dest, &data) {
+    with_active_node(node, |n| match n.send_packet_queued(&dest, &data) {
         Ok(ph) => HttpResponse::ok(json!({
             "status": "sent",
             "packet_hash": to_hex(&ph.0),

--- a/rns-git/src/client.rs
+++ b/rns-git/src/client.rs
@@ -1063,7 +1063,7 @@ destination.set_link_established_callback(link_established)
 
 def announce_loop():
     while running:
-        destination.announce()
+        destination.announce_queued()
         time.sleep(0.25)
 
 threading.Thread(target=announce_loop, daemon=True).start()

--- a/rns-git/src/client.rs
+++ b/rns-git/src/client.rs
@@ -1063,7 +1063,7 @@ destination.set_link_established_callback(link_established)
 
 def announce_loop():
     while running:
-        destination.announce_queued()
+        destination.announce()
         time.sleep(0.25)
 
 threading.Thread(target=announce_loop, daemon=True).start()

--- a/rns-git/src/server.rs
+++ b/rns-git/src/server.rs
@@ -52,9 +52,9 @@ pub fn run_server(config: ServerConfig, identity: Identity) -> Result<()> {
 
     loop {
         thread::sleep(announce_interval);
-        let _ = node.announce(&destinations.repositories, &identity, None);
+        let _ = node.announce_queued(&destinations.repositories, &identity, None);
         if let Some(page_destination) = destinations.nomadnet.as_ref() {
-            let _ = node.announce(
+            let _ = node.announce_queued(
                 page_destination,
                 &identity,
                 Some(config.node_name.as_bytes()),
@@ -129,7 +129,7 @@ pub fn register_repository_destination(
     )
     .map_err(|_| Error::msg("failed to register link destination"))?;
     register_handlers(node, config, access)?;
-    node.announce(&destination, identity, None)
+    node.announce_queued(&destination, identity, None)
         .map_err(|_| Error::msg("failed to announce rngit destination"))?;
     Ok(destination)
 }

--- a/rns-git/tests/e2e.rs
+++ b/rns-git/tests/e2e.rs
@@ -358,7 +358,7 @@ fn rngit_nomadnet_pages_render_over_rns_link() {
             }
             harness
                 .server_node
-                .announce(page_destination, &harness.server_identity, None)
+                .announce_queued(page_destination, &harness.server_identity, None)
                 .unwrap();
             std::thread::sleep(Duration::from_millis(250));
         }
@@ -869,7 +869,7 @@ fn wait_for_announce(
     let deadline = Instant::now() + timeout;
     loop {
         server_node
-            .announce(destination, server_identity, app_data)
+            .announce_queued(destination, server_identity, app_data)
             .expect("reannounce should succeed");
         match rx.recv_timeout(Duration::from_millis(500)) {
             Ok(Event::Announce(announced)) if announced.dest_hash == dest_hash => {

--- a/rns-net/Cargo.toml
+++ b/rns-net/Cargo.toml
@@ -33,6 +33,7 @@ rns-core.workspace = true
 rns-hooks-crate = { package = "rns-hooks", version = "0.1.10", path = "../rns-hooks", optional = true, default-features = false }
 rns-crypto.workspace = true
 log = "0.4"
+futures = { version = "0.3", default-features = false, features = ["std", "executor"] }
 rayon = "1"
 libc = "0.2"
 socket2 = { version = "0.6", features = ["all"] }

--- a/rns-net/examples/echo.rs
+++ b/rns-net/examples/echo.rs
@@ -295,7 +295,7 @@ fn main() {
 
     // Announce the server destination
     server_node
-        .announce(&server_dest, &server_identity, Some(b"Rust Echo Server"))
+        .announce_queued(&server_dest, &server_identity, Some(b"Rust Echo Server"))
         .expect("Failed to announce");
 
     log::info!("Server announced");
@@ -329,7 +329,7 @@ fn main() {
     log::info!("Sending echo request: {:?}", std::str::from_utf8(message));
 
     let packet_hash = client_node
-        .send_packet(&client_dest, message)
+        .send_packet_queued(&client_dest, message)
         .expect("Failed to send packet");
 
     log::info!("Sent packet: hash={}", packet_hash);

--- a/rns-net/examples/message.rs
+++ b/rns-net/examples/message.rs
@@ -450,11 +450,12 @@ fn main() {
     // ─── Announce Both ───────────────────────────────────────────────────
 
     println!("Announcing...");
-    alice_node
-        .announce(&alice_dest, &alice_identity, Some(b"Alice"))
+    futures::executor::block_on(alice_node.announce(&alice_dest, &alice_identity, Some(b"Alice")))
         .expect("Alice announce failed");
     bob_node
-        .announce(&bob_dest, &bob_identity, Some(b"Bob"))
+        .try_announce(&bob_dest, &bob_identity, Some(b"Bob"))
+        .expect("Bob announce admission failed")
+        .wait()
         .expect("Bob announce failed");
 
     // ─── Wait for Cross-Discovery ────────────────────────────────────────
@@ -493,8 +494,7 @@ fn main() {
         "Alice sending: {:?}",
         std::str::from_utf8(alice_msg).unwrap()
     );
-    let alice_pkt = alice_node
-        .send_packet(&dest_to_bob, alice_msg)
+    let alice_pkt = futures::executor::block_on(alice_node.send_packet(&dest_to_bob, alice_msg))
         .expect("Alice send failed");
 
     // Bob → Alice
@@ -502,7 +502,9 @@ fn main() {
     let bob_msg = b"Hello Alice!";
     println!("Bob sending: {:?}", std::str::from_utf8(bob_msg).unwrap());
     let bob_pkt = bob_node
-        .send_packet(&dest_to_alice, bob_msg)
+        .try_send_packet(&dest_to_alice, bob_msg)
+        .expect("Bob send admission failed")
+        .wait()
         .expect("Bob send failed");
 
     // ─── Receive + Decrypt ───────────────────────────────────────────────

--- a/rns-net/examples/weave_hil.rs
+++ b/rns-net/examples/weave_hil.rs
@@ -91,7 +91,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                 parent.peers
             );
             if parent.status && !peers.is_empty() && !announced {
-                node.announce(&destination, &identity, Some(b"rns-rs Weave HIL"))?;
+                node.announce_queued(&destination, &identity, Some(b"rns-rs Weave HIL"))?;
                 announced = true;
             }
         }

--- a/rns-net/src/common/event.rs
+++ b/rns-net/src/common/event.rs
@@ -904,6 +904,10 @@ pub struct LocalDestinationEntry {
 #[derive(Debug, Clone)]
 pub struct LinkInfoEntry {
     pub link_id: [u8; 16],
+    /// Confirmed sends admitted locally but not yet fully written (including the current write).
+    pub pending_send_packets: usize,
+    /// Polled async sends waiting for local admission capacity.
+    pub waiting_send_packets: usize,
     pub state: String,
     pub is_initiator: bool,
     pub dest_hash: [u8; 16],

--- a/rns-net/src/common/event.rs
+++ b/rns-net/src/common/event.rs
@@ -167,6 +167,15 @@ pub struct DrainStatus {
     pub detail: Option<String>,
 }
 
+/// Replay metadata carried atomically with an explicit announcement.
+#[doc(hidden)]
+pub struct AnnounceReplay {
+    pub dest_hash: [u8; 16],
+    pub name_hash: [u8; 10],
+    pub identity_prv_key: [u8; 64],
+    pub app_data: Option<Vec<u8>>,
+}
+
 /// Events sent to the driver thread.
 ///
 /// `W` is the writer type (e.g. `Box<dyn Writer>` for sync,
@@ -220,6 +229,13 @@ pub enum Event<W: Send> {
         raw: Vec<u8>,
         dest_type: u8,
         attached_interface: Option<InterfaceId>,
+    },
+    /// A locally originated packet with transmission completion tracking.
+    SendOutboundTracked {
+        raw: Vec<u8>,
+        dest_type: u8,
+        replay: Option<Box<AnnounceReplay>>,
+        completion: crate::link_send::Completion,
     },
     /// Register a local destination.
     RegisterDestination { dest_hash: [u8; 16], dest_type: u8 },
@@ -1035,7 +1051,8 @@ impl<W: Send> fmt::Debug for Event<W> {
                 .field("timeout", timeout)
                 .finish(),
             Event::Shutdown => write!(f, "Shutdown"),
-            Event::SendOutbound { raw, dest_type, .. } => f
+            Event::SendOutbound { raw, dest_type, .. }
+            | Event::SendOutboundTracked { raw, dest_type, .. } => f
                 .debug_struct("SendOutbound")
                 .field("raw_len", &raw.len())
                 .field("dest_type", dest_type)

--- a/rns-net/src/common/event.rs
+++ b/rns-net/src/common/event.rs
@@ -324,7 +324,16 @@ pub enum Event<W: Send> {
         payload: Vec<u8>,
         response_tx: mpsc::Sender<Result<(), String>>,
     },
-    /// Send generic data on a link with a given context.
+    /// Wake the driver after outbound writer capacity changes.
+    LinkWriterReady,
+    /// Send generic data on a link with transmission completion.
+    SendLinkTracked {
+        link_id: [u8; 16],
+        data: Vec<u8>,
+        context: u8,
+        completion: crate::link_send::Completion,
+    },
+    /// Legacy best-effort datagram admission, without transmission completion.
     SendOnLink {
         link_id: [u8; 16],
         data: Vec<u8>,
@@ -1142,7 +1151,14 @@ impl<W: Send> fmt::Debug for Event<W> {
                 .field("msgtype", msgtype)
                 .field("payload_len", &payload.len())
                 .finish(),
+            Event::LinkWriterReady => f.write_str("LinkWriterReady"),
             Event::SendOnLink {
+                link_id,
+                data,
+                context,
+                ..
+            }
+            | Event::SendLinkTracked {
                 link_id,
                 data,
                 context,

--- a/rns-net/src/common/link_manager.rs
+++ b/rns-net/src/common/link_manager.rs
@@ -1891,6 +1891,8 @@ impl LinkManager {
                 };
                 crate::event::LinkInfoEntry {
                     link_id: *link_id,
+                    pending_send_packets: 0,
+                    waiting_send_packets: 0,
                     state: state.to_string(),
                     is_initiator: managed.engine.is_initiator(),
                     dest_hash: managed.dest_hash,

--- a/rns-net/src/driver.rs
+++ b/rns-net/src/driver.rs
@@ -636,6 +636,8 @@ impl TrafficSample {
 
 /// The driver loop. Owns the engine and all interface entries.
 pub struct Driver {
+    pub(crate) tracked_link_send: Option<([u8; 32], crate::link_send::Completion)>,
+    pub(crate) pending_link_frames: std::collections::VecDeque<PendingLinkFrame>,
     pub(crate) engine: TransportEngine,
     pub(crate) interfaces: HashMap<InterfaceId, InterfaceEntry>,
     /// Parent listener for dynamically spawned interfaces.
@@ -870,6 +872,8 @@ impl Driver {
                 .queue_max_bytes,
         };
         Driver {
+            tracked_link_send: None,
+            pending_link_frames: std::collections::VecDeque::new(),
             engine,
             interfaces: HashMap::new(),
             dynamic_interface_parents: HashMap::new(),
@@ -1312,4 +1316,10 @@ impl Driver {
         self.holepunch_manager = HolePunchManager::new(addrs, protocol, device);
         self.holepunch_manager.set_underlay_mark(self.underlay_mark);
     }
+}
+
+pub(crate) struct PendingLinkFrame {
+    interface: InterfaceId,
+    data: Vec<u8>,
+    completion: Option<crate::link_send::Completion>,
 }

--- a/rns-net/src/driver.rs
+++ b/rns-net/src/driver.rs
@@ -1321,5 +1321,6 @@ impl Driver {
 pub(crate) struct PendingLinkFrame {
     interface: InterfaceId,
     data: Vec<u8>,
+    is_announce: bool,
     completion: Option<crate::link_send::Completion>,
 }

--- a/rns-net/src/driver/dispatch.rs
+++ b/rns-net/src/driver/dispatch.rs
@@ -1,6 +1,50 @@
 use super::*;
 
 impl Driver {
+    /// Pending frames own admission permits until actual writer completion,
+    /// bounding this queue together with driver events and in-flight writes.
+    pub(crate) fn flush_pending_link_frames(&mut self) {
+        use crate::link_send::LinkSendError;
+        let mut blocked = std::collections::HashSet::new();
+        for _ in 0..self.pending_link_frames.len() {
+            let mut frame = self.pending_link_frames.pop_front().unwrap();
+            if blocked.contains(&frame.interface) {
+                self.pending_link_frames.push_back(frame);
+                continue;
+            }
+            let Some(entry) = self
+                .interfaces
+                .get_mut(&frame.interface)
+                .filter(|e| e.online && e.enabled)
+            else {
+                if let Some(completion) = frame.completion.take() {
+                    completion.finish(Err(LinkSendError::InterfaceUnavailable));
+                }
+                continue;
+            };
+            match entry
+                .writer
+                .enqueue_confirmed(&frame.data, &mut frame.completion)
+            {
+                Ok(()) => {
+                    entry.stats.txb += frame.data.len() as u64;
+                    entry.stats.tx_packets += 1;
+                }
+                Err(error)
+                    if error.kind() == std::io::ErrorKind::WouldBlock
+                        && frame.completion.is_some() =>
+                {
+                    blocked.insert(frame.interface);
+                    self.pending_link_frames.push_back(frame);
+                }
+                Err(error) => {
+                    if let Some(completion) = frame.completion.take() {
+                        completion.finish(Err(LinkSendError::WriteFailed(error.to_string())));
+                    }
+                }
+            }
+        }
+    }
     pub(crate) fn authorize_direct_connect_proposal(
         &mut self,
         policy: crate::event::HolePunchPolicy,
@@ -353,6 +397,23 @@ impl Driver {
                 entry.online,
                 entry.enabled
             );
+            return;
+        }
+        let tracked = self.tracked_link_send.as_ref().is_some_and(|(hash, _)| {
+            RawPacket::unpack(&raw).is_ok_and(|packet| packet.packet_hash == *hash)
+        });
+        if tracked {
+            let data = if let Some(ref state) = entry.ifac {
+                ifac::mask_outbound(&raw, state)
+            } else {
+                raw.to_vec()
+            };
+            let (_, completion) = self.tracked_link_send.take().unwrap();
+            self.pending_link_frames.push_back(PendingLinkFrame {
+                interface,
+                data,
+                completion: Some(completion),
+            });
             return;
         }
         if Self::interface_send_deferred(entry, Instant::now()) {

--- a/rns-net/src/driver/dispatch.rs
+++ b/rns-net/src/driver/dispatch.rs
@@ -1,6 +1,78 @@
 use super::*;
 
 impl Driver {
+    pub(crate) fn handle_confirmed_outbound(
+        &mut self,
+        raw: Vec<u8>,
+        dest_type: u8,
+        replay: Option<Box<crate::common::event::AnnounceReplay>>,
+        completion: crate::link_send::Completion,
+    ) {
+        use crate::link_send::LinkSendError;
+        if self.is_draining() {
+            completion.finish(Err(LinkSendError::Draining));
+            return;
+        }
+        let Ok(packet) = RawPacket::unpack(&raw) else {
+            completion.finish(Err(LinkSendError::PacketBuildFailed));
+            return;
+        };
+        if let Some(replay) = replay {
+            let crate::common::event::AnnounceReplay {
+                dest_hash,
+                name_hash,
+                identity_prv_key,
+                app_data,
+            } = *replay;
+            self.shared_announces.insert(
+                dest_hash,
+                SharedAnnounceRecord {
+                    name_hash,
+                    identity_prv_key,
+                    app_data,
+                },
+            );
+        }
+        let now = time::now();
+        if packet.flags.packet_type == rns_core::constants::PACKET_TYPE_DATA {
+            self.sent_packets
+                .insert(packet.packet_hash, (packet.destination_hash, now));
+        }
+        // These APIs originate hops=0 packets, so announcement relay bandwidth
+        // queues do not apply. Retain the normal routing and per-send hooks.
+        let actions = self.engine.handle_outbound(&packet, dest_type, None, now);
+        let mut selected = 0;
+        for action in actions {
+            match action {
+                TransportAction::SendOnInterface { interface, raw } => {
+                    selected += 1;
+                    self.tracked_link_send = Some((packet.packet_hash, completion.branch()));
+                    self.dispatch_all(vec![TransportAction::SendOnInterface { interface, raw }]);
+                    if let Some((_, branch)) = self.tracked_link_send.take() {
+                        branch.finish(Err(LinkSendError::Rejected));
+                    }
+                }
+                TransportAction::BroadcastOnAllInterfaces { raw, exclude } => {
+                    // Broadcast hooks still run in dispatch_broadcast_action.
+                    self.tracked_link_send = Some((packet.packet_hash, completion.branch()));
+                    self.dispatch_all(vec![TransportAction::BroadcastOnAllInterfaces {
+                        raw,
+                        exclude,
+                    }]);
+                    if let Some((_, branch)) = self.tracked_link_send.take() {
+                        branch.finish(Err(LinkSendError::Rejected));
+                    }
+                    selected += 1;
+                }
+                other => self.dispatch_all(vec![other]),
+            }
+        }
+        completion.finish(if selected == 0 {
+            Err(LinkSendError::NoRoute)
+        } else {
+            Ok(())
+        });
+    }
     /// Pending frames own admission permits until actual writer completion,
     /// bounding this queue together with driver events and in-flight writes.
     pub(crate) fn flush_pending_link_frames(&mut self) {
@@ -29,6 +101,11 @@ impl Driver {
                 Ok(()) => {
                     entry.stats.txb += frame.data.len() as u64;
                     entry.stats.tx_packets += 1;
+                    if frame.is_announce {
+                        entry
+                            .stats
+                            .record_outgoing_announce_bytes(time::now(), frame.data.len());
+                    }
                 }
                 Err(error)
                     if error.kind() == std::io::ErrorKind::WouldBlock
@@ -412,6 +489,7 @@ impl Driver {
             self.pending_link_frames.push_back(PendingLinkFrame {
                 interface,
                 data,
+                is_announce,
                 completion: Some(completion),
             });
             return;
@@ -522,6 +600,33 @@ impl Driver {
 
         let is_announce = raw.len() > 2 && (raw[0] & 0x03) == 0x01;
         let is_path_request = is_outbound_path_request(&raw, &self.path_request_dest);
+        if self.tracked_link_send.as_ref().is_some_and(|(hash, _)| {
+            RawPacket::unpack(&raw).is_ok_and(|packet| packet.packet_hash == *hash)
+        }) {
+            let (_, completion) = self.tracked_link_send.take().unwrap();
+            let mut selected = 0;
+            for entry in self.interfaces.values() {
+                if entry.online && entry.enabled && Some(entry.id) != exclude {
+                    selected += 1;
+                    let data = entry
+                        .ifac
+                        .as_ref()
+                        .map_or_else(|| raw.to_vec(), |state| ifac::mask_outbound(&raw, state));
+                    self.pending_link_frames.push_back(PendingLinkFrame {
+                        interface: entry.id,
+                        data,
+                        is_announce,
+                        completion: Some(completion.branch()),
+                    });
+                }
+            }
+            completion.finish(if selected == 0 {
+                Err(crate::link_send::LinkSendError::NoRoute)
+            } else {
+                Ok(())
+            });
+            return;
+        }
         for entry in self.interfaces.values_mut() {
             if entry.online && entry.enabled && Some(entry.id) != exclude {
                 if Self::interface_send_deferred(entry, Instant::now()) {

--- a/rns-net/src/driver/events.rs
+++ b/rns-net/src/driver/events.rs
@@ -1012,6 +1012,14 @@ impl Driver {
                     dest_type,
                     attached_interface,
                 } => self.handle_send_outbound_event(raw, dest_type, attached_interface),
+                Event::SendOutboundTracked {
+                    raw,
+                    dest_type,
+                    replay,
+                    completion,
+                } => {
+                    self.handle_confirmed_outbound(raw, dest_type, replay, completion);
+                }
                 Event::RegisterDestination {
                     dest_hash,
                     dest_type,

--- a/rns-net/src/driver/events.rs
+++ b/rns-net/src/driver/events.rs
@@ -945,6 +945,7 @@ impl Driver {
     /// Run the event loop. Blocks until Shutdown or all senders are dropped.
     pub fn run(&mut self) {
         loop {
+            self.flush_pending_link_frames();
             let received = match self.rx.recv_classified() {
                 Ok(e) => e,
                 Err(_) => break, // all senders dropped
@@ -1325,6 +1326,48 @@ impl Driver {
                         Err(err) => {
                             let _ = response_tx.send(Err(err));
                         }
+                    }
+                }
+                Event::LinkWriterReady => {}
+                Event::SendLinkTracked {
+                    link_id,
+                    data,
+                    context,
+                    completion,
+                } => {
+                    use crate::link_send::LinkSendError;
+                    if self.is_draining() {
+                        completion.finish(Err(LinkSendError::Draining));
+                        continue;
+                    }
+                    match self.link_manager.try_send_on_link(
+                        &link_id,
+                        &data,
+                        context,
+                        &mut self.rng,
+                    ) {
+                        Ok(actions) => {
+                            if self.link_manager.get_link_route_hint(&link_id).is_none() {
+                                completion.finish(Err(LinkSendError::NoRoute));
+                                continue;
+                            }
+                            let hash = actions.iter().find_map(|action| match action {
+                                LinkManagerAction::SendPacket { raw, .. } => {
+                                    RawPacket::unpack(raw).ok().map(|p| p.packet_hash)
+                                }
+                                _ => None,
+                            });
+                            if let Some(hash) = hash {
+                                self.tracked_link_send = Some((hash, completion));
+                                self.dispatch_link_actions(actions);
+                                if let Some((_, completion)) = self.tracked_link_send.take() {
+                                    completion.finish(Err(LinkSendError::Rejected));
+                                }
+                            } else {
+                                completion.finish(Err(LinkSendError::Rejected));
+                            }
+                        }
+                        Err(error) => completion.finish(Err(LinkSendError::InvalidPacket(error))),
                     }
                 }
                 Event::SendOnLink {
@@ -2025,11 +2068,15 @@ impl Driver {
                     let _ = (server_interface_id, peer_ip, penalty_level, blacklist_for);
                 }
                 Event::Shutdown => {
+                    self.event_tx.link_send_pool().close();
+                    self.pending_link_frames.clear();
                     self.graceful_shutdown();
                     break;
                 }
             }
         }
+        self.event_tx.link_send_pool().close();
+        self.pending_link_frames.clear();
     }
     pub(crate) fn handle_tunnel_synth_delivery(
         &mut self,

--- a/rns-net/src/driver/lifecycle.rs
+++ b/rns-net/src/driver/lifecycle.rs
@@ -232,6 +232,7 @@ impl Driver {
         let active_resource_transfers = self.link_manager.resource_transfer_count();
         let active_holepunch_sessions = self.holepunch_manager.session_count();
         let interface_writer_queued_frames = self.interface_writer_queued_frames();
+        let link_transmissions = self.event_tx.link_send_pool().in_flight();
         #[cfg(feature = "hooks")]
         let (provider_backlog_events, provider_consumer_queued_events) = self
             .provider_bridge
@@ -277,6 +278,9 @@ impl Driver {
                         "{interface_writer_queued_frames} queued interface writer frame(s)"
                     ));
                 }
+                if link_transmissions > 0 {
+                    remaining.push(format!("{link_transmissions} pending Link transmission(s)"));
+                }
                 if provider_backlog_events > 0 {
                     remaining.push(format!(
                         "{provider_backlog_events} provider backlog event(s)"
@@ -309,6 +313,7 @@ impl Driver {
                     && active_resource_transfers == 0
                     && active_holepunch_sessions == 0
                     && interface_writer_queued_frames == 0
+                    && link_transmissions == 0
                     && provider_backlog_events == 0
                     && provider_consumer_queued_events == 0),
             interface_writer_queued_frames,
@@ -330,6 +335,8 @@ impl Driver {
         }
 
         log::info!("driver drain deadline reached; tearing down remaining links");
+        self.event_tx.link_send_pool().close();
+        self.pending_link_frames.clear();
         self.lifecycle_state = LifecycleState::Stopping;
         let resource_actions = self.link_manager.cancel_all_resources(&mut self.rng);
         self.dispatch_link_actions(resource_actions);

--- a/rns-net/src/driver/queries.rs
+++ b/rns-net/src/driver/queries.rs
@@ -669,7 +669,17 @@ impl Driver {
                     .collect();
                 QueryResponse::LocalDestinations(entries)
             }
-            QueryRequest::Links => QueryResponse::Links(self.link_manager.link_entries()),
+            QueryRequest::Links => {
+                let counts = self.event_tx.link_send_pool().snapshot();
+                let mut links = self.link_manager.link_entries();
+                for link in &mut links {
+                    if let Some(counts) = counts.get(&link.link_id) {
+                        link.pending_send_packets = counts.pending;
+                        link.waiting_send_packets = counts.waiting;
+                    }
+                }
+                QueryResponse::Links(links)
+            }
             QueryRequest::Resources => {
                 QueryResponse::Resources(self.link_manager.resource_entries())
             }

--- a/rns-net/src/driver/tests.rs
+++ b/rns-net/src/driver/tests.rs
@@ -1610,6 +1610,101 @@ fn make_entry(id: u64, writer: Box<dyn Writer>, online: bool) -> InterfaceEntry 
 }
 
 #[test]
+fn confirmed_outbound_fanout_waits_for_all_interfaces_and_reports_partial_failure() {
+    use crate::link_send::{Completion, LinkSendError};
+    use futures::FutureExt;
+    struct HeldWriter(Arc<Mutex<Vec<Completion>>>, bool);
+    impl Writer for HeldWriter {
+        fn send_frame(&mut self, _: &[u8]) -> io::Result<()> {
+            panic!("confirmed send bypassed completion tracking")
+        }
+        fn enqueue_confirmed(
+            &mut self,
+            _: &[u8],
+            completion: &mut Option<Completion>,
+        ) -> io::Result<()> {
+            if self.1 {
+                self.1 = false;
+                return Err(io::ErrorKind::WouldBlock.into());
+            }
+            self.0.lock().unwrap().push(completion.take().unwrap());
+            Ok(())
+        }
+    }
+    // PLAIN uses BroadcastOnAllInterfaces, while a local announce produces
+    // individual SendOnInterface actions. Exercise both fanout paths.
+    for (packet_type, fail_first) in [
+        (constants::PACKET_TYPE_DATA, false),
+        (constants::PACKET_TYPE_DATA, true),
+        (constants::PACKET_TYPE_ANNOUNCE, false),
+        (constants::PACKET_TYPE_ANNOUNCE, true),
+    ] {
+        let (tx, rx) = event::channel_with_capacity(1);
+        let (cbs, ..) = MockCallbacks::new();
+        let mut driver = Driver::new(make_transport_config(false), rx, tx.clone(), Box::new(cbs));
+        let first = Arc::new(Mutex::new(Vec::new()));
+        let second = Arc::new(Mutex::new(Vec::new()));
+        for (id, held) in [(1, first.clone()), (2, second.clone())] {
+            let entry = make_entry(id, Box::new(HeldWriter(held, true)), true);
+            driver.engine.register_interface(entry.info.clone());
+            driver.interfaces.insert(entry.id, entry);
+        }
+        let dest = [0x31; 16];
+        let dest_type = if packet_type == constants::PACKET_TYPE_DATA {
+            constants::DESTINATION_PLAIN
+        } else {
+            constants::DESTINATION_SINGLE
+        };
+        driver.engine.register_destination(dest, dest_type);
+        let packet = RawPacket::pack(
+            PacketFlags {
+                header_type: constants::HEADER_1,
+                context_flag: constants::FLAG_UNSET,
+                transport_type: constants::TRANSPORT_BROADCAST,
+                destination_type: dest_type,
+                packet_type,
+            },
+            0,
+            &dest,
+            None,
+            constants::CONTEXT_NONE,
+            b"confirmed",
+        )
+        .unwrap();
+        let (completion, mut receipt) = Completion::new(tx.link_send_pool().try_acquire().unwrap());
+        driver.handle_confirmed_outbound(packet.raw, dest_type, None, completion);
+        driver.flush_pending_link_frames();
+        assert!(first.lock().unwrap().is_empty());
+        assert!(second.lock().unwrap().is_empty());
+        assert_eq!(driver.pending_link_frames.len(), 2);
+        assert!((&mut receipt).now_or_never().is_none());
+        driver.flush_pending_link_frames();
+        assert!(driver.pending_link_frames.is_empty());
+        assert_eq!(first.lock().unwrap().len(), 1);
+        assert_eq!(second.lock().unwrap().len(), 1);
+        let expected = if fail_first {
+            Err(LinkSendError::WriteFailed("broken pipe".into()))
+        } else {
+            Ok(())
+        };
+        first
+            .lock()
+            .unwrap()
+            .pop()
+            .unwrap()
+            .finish(expected.clone());
+        assert!((&mut receipt).now_or_never().is_none());
+        assert!(matches!(
+            tx.link_send_pool().try_acquire(),
+            Err(LinkSendError::QueueFull)
+        ));
+        second.lock().unwrap().pop().unwrap().finish(Ok(()));
+        assert_eq!(receipt.wait(), expected);
+        assert_eq!(tx.link_send_pool().in_flight(), 0);
+    }
+}
+
+#[test]
 fn driver_validates_and_routes_mismatched_lrproof_using_known_identity() {
     use rns_crypto::ed25519::Ed25519PrivateKey;
 

--- a/rns-net/src/event.rs
+++ b/rns-net/src/event.rs
@@ -136,12 +136,29 @@ impl QueueState {
 }
 
 struct QueueShared {
+    link_sends: Arc<crate::link_send::SendPool>,
+    async_waiters: Mutex<Vec<std::sync::Weak<crate::link_send::Waiter>>>,
     state: Mutex<QueueState>,
     changed: Condvar,
     sender_count: AtomicUsize,
     control_capacity: usize,
     inbound_capacities: [usize; INBOUND_QUEUE_COUNT],
     path_request_dest: [u8; 16],
+}
+
+impl QueueShared {
+    fn wake_async_senders(&self) {
+        let waiters: Vec<_> = self
+            .async_waiters
+            .lock()
+            .unwrap()
+            .iter()
+            .filter_map(|w| w.upgrade())
+            .collect();
+        for waiter in waiters {
+            waiter.wake();
+        }
+    }
 }
 
 /// Sender for the prioritized driver event queue.
@@ -200,6 +217,37 @@ impl Drop for EventSender {
 }
 
 impl EventSender {
+    pub(crate) fn link_send_pool(&self) -> &Arc<crate::link_send::SendPool> {
+        &self.shared.link_sends
+    }
+
+    pub(crate) async fn send_async(
+        &self,
+        event: Event,
+    ) -> Result<(), crate::link_send::LinkSendError> {
+        use crate::link_send::{LinkSendError, Waiter};
+        let waiter = Arc::new(Waiter::default());
+        {
+            let mut waiters = self.shared.async_waiters.lock().unwrap();
+            waiters.retain(|w| w.strong_count() > 0);
+            waiters.push(Arc::downgrade(&waiter));
+        }
+        let mut pending = Some(event);
+        futures::future::poll_fn(|cx| {
+            waiter.register(cx);
+            match self.try_send(pending.take().unwrap()) {
+                Ok(()) => std::task::Poll::Ready(Ok(())),
+                Err(std::sync::mpsc::TrySendError::Full(event)) => {
+                    pending = Some(event);
+                    std::task::Poll::Pending
+                }
+                Err(std::sync::mpsc::TrySendError::Disconnected(_)) => {
+                    std::task::Poll::Ready(Err(LinkSendError::DriverStopped))
+                }
+            }
+        })
+        .await
+    }
     fn classify(&self, event: &Event, state: &QueueState) -> Option<QueueClass> {
         let Event::Frame {
             interface_id, data, ..
@@ -398,6 +446,8 @@ impl Drop for EventReceiver {
         state.receiver_alive = false;
         drop(state);
         self.shared.changed.notify_all();
+        self.shared.link_sends.close();
+        self.shared.wake_async_senders();
     }
 }
 
@@ -418,6 +468,8 @@ impl EventReceiver {
         let mut state = self.shared.state.lock().unwrap_or_else(|p| p.into_inner());
         loop {
             if let Some(event) = self.pop_locked(&mut state) {
+                drop(state);
+                self.shared.wake_async_senders();
                 return Ok(event);
             }
             if self.shared.sender_count.load(Ordering::Acquire) == 0 {
@@ -434,6 +486,8 @@ impl EventReceiver {
     pub fn try_recv(&self) -> Result<Event, std::sync::mpsc::TryRecvError> {
         let mut state = self.shared.state.lock().unwrap_or_else(|p| p.into_inner());
         if let Some(event) = self.pop_locked(&mut state) {
+            drop(state);
+            self.shared.wake_async_senders();
             return Ok(event.event);
         }
         if self.shared.sender_count.load(Ordering::Acquire) == 0 {
@@ -451,6 +505,8 @@ impl EventReceiver {
         let mut state = self.shared.state.lock().unwrap_or_else(|p| p.into_inner());
         loop {
             if let Some(event) = self.pop_locked(&mut state) {
+                drop(state);
+                self.shared.wake_async_senders();
                 return Ok(event.event);
             }
             if self.shared.sender_count.load(Ordering::Acquire) == 0 {
@@ -492,6 +548,8 @@ pub(crate) fn channel_with_queue_capacities(
     inbound_capacities: InboundQueueCapacities,
 ) -> (EventSender, EventReceiver) {
     let shared = Arc::new(QueueShared {
+        link_sends: crate::link_send::SendPool::new(control_capacity),
+        async_waiters: Mutex::new(Vec::new()),
         state: Mutex::new(QueueState::new()),
         changed: Condvar::new(),
         sender_count: AtomicUsize::new(1),
@@ -520,6 +578,25 @@ mod tests {
     use std::sync::mpsc::TrySendError;
     use std::time::Duration;
 
+    #[test]
+    fn async_control_send_waits_for_space_and_handles_receiver_shutdown() {
+        use futures::{executor::block_on, FutureExt};
+        let (tx, rx) = channel_with_capacity(1);
+        tx.try_send(Event::Tick).unwrap();
+        let mut pending = Box::pin(tx.send_async(Event::Shutdown));
+        assert!(pending.as_mut().now_or_never().is_none());
+        assert!(matches!(rx.try_recv(), Ok(Event::Tick)));
+        block_on(pending).unwrap();
+        assert!(matches!(rx.try_recv(), Ok(Event::Shutdown)));
+        tx.try_send(Event::Tick).unwrap();
+        let mut pending = Box::pin(tx.send_async(Event::Shutdown));
+        assert!(pending.as_mut().now_or_never().is_none());
+        drop(rx);
+        assert_eq!(
+            block_on(pending),
+            Err(crate::link_send::LinkSendError::DriverStopped)
+        );
+    }
     fn frame(interface_id: u64, destination: [u8; 16], packet_type: u8) -> Event {
         let raw = RawPacket::pack(
             PacketFlags {

--- a/rns-net/src/event.rs
+++ b/rns-net/src/event.rs
@@ -324,6 +324,9 @@ impl EventSender {
         }
         let sequence = state.next_sequence;
         state.next_sequence = state.next_sequence.wrapping_add(1);
+        if let Event::SendLinkTracked { completion, .. } = &event {
+            completion.admit();
+        }
         state.control.push_back(QueuedEvent { sequence, event });
         drop(state);
         self.shared.changed.notify_one();

--- a/rns-net/src/interface/backbone.rs
+++ b/rns-net/src/interface/backbone.rs
@@ -381,6 +381,22 @@ struct BackboneWriter {
 }
 
 impl Writer for BackboneWriter {
+    fn send_frame_confirmed(&mut self, data: &[u8]) -> io::Result<()> {
+        // The async writer has already reserved this frame's byte budget.
+        // Once admitted, retain it even if the egress gate subsequently closes.
+        if !self
+            .transmit_buffer
+            .append_with_limit(hdlc::frame(data), Some(EGRESS_HIGH_WATERMARK))
+        {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "confirmed frame exceeds backbone buffer",
+            ));
+        }
+        self.transmit_buffer.flush();
+        let timeout = lock_or_recover(&self.runtime, "backbone runtime").write_stall_timeout;
+        self.drain_transmit(timeout)
+    }
     fn send_frame(&mut self, data: &[u8]) -> io::Result<()> {
         self.send_frames(&[data.to_vec()])
     }
@@ -1461,6 +1477,27 @@ struct BackboneClientWriter {
 }
 
 impl Writer for BackboneClientWriter {
+    fn send_frame_confirmed(&mut self, data: &[u8]) -> io::Result<()> {
+        if !self
+            .transmit_buffer
+            .append_with_limit(hdlc::frame(data), Some(EGRESS_HIGH_WATERMARK))
+        {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "confirmed frame exceeds backbone buffer",
+            ));
+        }
+        self.transmit_buffer.flush();
+        while self.transmit_buffer.sendable_bytes() > 0 {
+            if self.transmit_buffer.drain_to(&mut self.stream)? == 0 {
+                return Err(io::Error::new(
+                    io::ErrorKind::WriteZero,
+                    "backbone writer made no progress",
+                ));
+            }
+        }
+        Ok(())
+    }
     fn send_frame(&mut self, data: &[u8]) -> io::Result<()> {
         self.send_frames(&[data.to_vec()])
     }

--- a/rns-net/src/interface/kiss_iface.rs
+++ b/rns-net/src/interface/kiss_iface.rs
@@ -77,6 +77,7 @@ struct FlowState {
 /// Writer that sends KISS-framed data over a serial port.
 /// Handles flow control: when enabled, queues packets until CMD_READY.
 struct KissWriter {
+    confirmed_pending: Option<Vec<u8>>,
     file: std::fs::File,
     flow_control: bool,
     flow_state: Arc<Mutex<FlowState>>,
@@ -84,6 +85,32 @@ struct KissWriter {
 }
 
 impl Writer for KissWriter {
+    fn send_frame_confirmed(&mut self, data: &[u8]) -> io::Result<()> {
+        if !self.flow_control {
+            return self.send_frame(data);
+        }
+        let data = self
+            .ax25_source
+            .as_ref()
+            .map(|source| super::ax25_kiss::encode_ui_frame(source, data))
+            .unwrap_or_else(|| data.to_vec());
+        self.confirmed_pending = Some(kiss::frame(&data));
+        self.flush()
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        if self.confirmed_pending.is_none() {
+            return Ok(());
+        }
+        let mut state = lock_or_recover(&self.flow_state, "kiss flow state");
+        if !state.ready || !state.queue.is_empty() {
+            return Err(io::ErrorKind::WouldBlock.into());
+        }
+        state.ready = false;
+        state.lock_time = Instant::now();
+        drop(state);
+        self.file.write_all(&self.confirmed_pending.take().unwrap())
+    }
     fn send_frame(&mut self, data: &[u8]) -> io::Result<()> {
         let data = self
             .ax25_source
@@ -157,6 +184,7 @@ pub fn start(config: KissIfaceConfig, tx: EventSender) -> io::Result<Box<dyn Wri
         })?;
 
     Ok(Box::new(KissWriter {
+        confirmed_pending: None,
         file: writer_file,
         flow_control: config.flow_control,
         flow_state,
@@ -355,6 +383,7 @@ fn reconnect(
                         drop(state);
 
                         let new_writer: Box<dyn Writer> = Box::new(KissWriter {
+                            confirmed_pending: None,
                             file: cfg_writer,
                             flow_control: config.flow_control,
                             flow_state: flow_state.clone(),
@@ -596,6 +625,7 @@ mod tests {
         }));
 
         let mut writer = KissWriter {
+            confirmed_pending: None,
             file: writer_file,
             flow_control: false,
             flow_state,
@@ -716,6 +746,7 @@ mod tests {
         let writer_file = unsafe { std::fs::File::from_raw_fd(slave_fd) };
 
         let mut writer = KissWriter {
+            confirmed_pending: None,
             file: writer_file,
             flow_control: true,
             flow_state: flow_state.clone(),
@@ -760,6 +791,40 @@ mod tests {
         let state = flow_state.lock().unwrap();
         assert!(!state.ready);
         assert!(state.lock_time.elapsed() > Duration::from_secs(5));
+    }
+
+    #[test]
+    fn confirmed_kiss_frame_waits_for_ready_and_flushes_once() {
+        let (master_fd, slave_fd) = open_pty_pair().unwrap();
+        let mut master = unsafe { std::fs::File::from_raw_fd(master_fd) };
+        let state = Arc::new(Mutex::new(FlowState {
+            ready: false,
+            queue: VecDeque::new(),
+            lock_time: Instant::now(),
+        }));
+        let mut writer = KissWriter {
+            confirmed_pending: None,
+            file: unsafe { std::fs::File::from_raw_fd(slave_fd) },
+            flow_control: true,
+            flow_state: state.clone(),
+            ax25_source: None,
+        };
+        assert_eq!(
+            writer
+                .send_frame_confirmed(b"confirmed")
+                .unwrap_err()
+                .kind(),
+            io::ErrorKind::WouldBlock
+        );
+        assert!(state.lock().unwrap().queue.is_empty());
+        assert!(!poll_read(master.as_raw_fd(), 20));
+        state.lock().unwrap().ready = true;
+        Writer::flush(&mut writer).unwrap();
+        let mut actual = vec![0; kiss::frame(b"confirmed").len()];
+        master.read_exact(&mut actual).unwrap();
+        assert_eq!(actual, kiss::frame(b"confirmed"));
+        Writer::flush(&mut writer).unwrap();
+        assert!(!poll_read(master.as_raw_fd(), 20));
     }
 
     #[test]

--- a/rns-net/src/interface/local.rs
+++ b/rns-net/src/interface/local.rs
@@ -80,6 +80,23 @@ struct LocalWriter {
 }
 
 impl Writer for LocalWriter {
+    fn send_frame_confirmed(&mut self, data: &[u8]) -> io::Result<()> {
+        if self
+            .sleep_hold
+            .as_ref()
+            .is_some_and(ClientSleepHold::should_drop_outbound)
+        {
+            return Err(io::Error::new(
+                io::ErrorKind::PermissionDenied,
+                "local client has paused transmission",
+            ));
+        }
+        append_and_drain(
+            &mut self.transmit_buffer,
+            &mut self.stream,
+            &[data.to_vec()],
+        )
+    }
     fn send_frame(&mut self, data: &[u8]) -> io::Result<()> {
         self.send_frames(&[data.to_vec()])
     }
@@ -418,6 +435,23 @@ struct UnixLocalWriter {
 
 #[cfg(target_os = "linux")]
 impl Writer for UnixLocalWriter {
+    fn send_frame_confirmed(&mut self, data: &[u8]) -> io::Result<()> {
+        if self
+            .sleep_hold
+            .as_ref()
+            .is_some_and(ClientSleepHold::should_drop_outbound)
+        {
+            return Err(io::Error::new(
+                io::ErrorKind::PermissionDenied,
+                "local client has paused transmission",
+            ));
+        }
+        append_and_drain(
+            &mut self.transmit_buffer,
+            &mut self.stream,
+            &[data.to_vec()],
+        )
+    }
     fn send_frame(&mut self, data: &[u8]) -> io::Result<()> {
         self.send_frames(&[data.to_vec()])
     }
@@ -1146,6 +1180,13 @@ mod tests {
         assert!(n > 0);
 
         thread::sleep(Duration::from_millis(50));
+        assert_eq!(
+            writer
+                .send_frame_confirmed(b"confirmed")
+                .unwrap_err()
+                .kind(),
+            io::ErrorKind::PermissionDenied
+        );
         writer.send_frame(b"drop").unwrap();
         let err = client.read(&mut buf).unwrap_err();
         assert!(

--- a/rns-net/src/interface/mod.rs
+++ b/rns-net/src/interface/mod.rs
@@ -240,6 +240,26 @@ pub fn validate_underlay_mark(mark: Option<u32>) -> io::Result<()> {
 pub trait Writer: Send {
     fn send_frame(&mut self, data: &[u8]) -> io::Result<()>;
 
+    /// Write one frame without silently dropping it. WouldBlock means the
+    /// frame was accepted and `flush` must finish it before success is reported.
+    /// Writers with intentional drop policies must override this method.
+    fn send_frame_confirmed(&mut self, data: &[u8]) -> io::Result<()> {
+        self.send_frame(data)
+    }
+
+    /// Internal async-writer admission. Leaves completion untouched on failure.
+    #[doc(hidden)]
+    fn enqueue_confirmed(
+        &mut self,
+        _data: &[u8],
+        _completion: &mut Option<crate::link_send::Completion>,
+    ) -> io::Result<()> {
+        Err(io::Error::new(
+            io::ErrorKind::Unsupported,
+            "confirmed sends require an async interface writer",
+        ))
+    }
+
     fn send_frames(&mut self, frames: &[Vec<u8>]) -> io::Result<()> {
         for frame in frames {
             self.send_frame(frame)?;
@@ -429,10 +449,29 @@ struct AsyncWriter {
 struct QueuedFrame {
     data: Vec<u8>,
     reserved_bytes: usize,
+    completion: Option<crate::link_send::Completion>,
 }
 
 impl Writer for AsyncWriter {
     fn send_frame(&mut self, data: &[u8]) -> io::Result<()> {
+        self.enqueue(data, &mut None)
+    }
+
+    fn enqueue_confirmed(
+        &mut self,
+        data: &[u8],
+        completion: &mut Option<crate::link_send::Completion>,
+    ) -> io::Result<()> {
+        self.enqueue(data, completion)
+    }
+}
+
+impl AsyncWriter {
+    fn enqueue(
+        &mut self,
+        data: &[u8],
+        completion: &mut Option<crate::link_send::Completion>,
+    ) -> io::Result<()> {
         if !self.metrics.worker_alive() {
             return Err(io::Error::new(
                 io::ErrorKind::BrokenPipe,
@@ -443,6 +482,18 @@ impl Writer for AsyncWriter {
         let reserved_bytes = if let Some(control) = &self.metrics.egress_control {
             let framed_bytes = crate::hdlc::framed_len(data);
             if !control.try_reserve(framed_bytes) {
+                if completion.is_some() {
+                    if framed_bytes > control.byte_limit {
+                        return Err(io::Error::new(
+                            io::ErrorKind::InvalidInput,
+                            "frame exceeds interface byte budget",
+                        ));
+                    }
+                    return Err(io::Error::new(
+                        io::ErrorKind::WouldBlock,
+                        "interface egress budget is full",
+                    ));
+                }
                 control.record_drop(framed_bytes);
                 return Ok(());
             }
@@ -456,9 +507,11 @@ impl Writer for AsyncWriter {
         match self.tx.try_send(QueuedFrame {
             data: data.to_vec(),
             reserved_bytes,
+            completion: completion.take(),
         }) {
             Ok(()) => Ok(()),
             Err(TrySendError::Full(frame)) => {
+                *completion = frame.completion;
                 self.metrics.queued_frames.fetch_sub(1, Ordering::Relaxed);
                 if let Some(control) = &self.metrics.egress_control {
                     control.release(frame.reserved_bytes);
@@ -469,6 +522,7 @@ impl Writer for AsyncWriter {
                 ))
             }
             Err(TrySendError::Disconnected(frame)) => {
+                *completion = frame.completion;
                 self.metrics.queued_frames.fetch_sub(1, Ordering::Relaxed);
                 if let Some(control) = &self.metrics.egress_control {
                     control.release(frame.reserved_bytes);
@@ -544,12 +598,70 @@ fn async_writer_loop(
         let mut queued = vec![first];
         queued.extend(rx.try_iter());
         let reserved_bytes = queued.iter().map(|frame| frame.reserved_bytes).sum();
-        let frames: Vec<_> = queued.into_iter().map(|frame| frame.data).collect();
         metrics
             .queued_frames
-            .fetch_sub(frames.len(), Ordering::Relaxed);
+            .fetch_sub(queued.len(), Ordering::Relaxed);
+        if event_tx.link_send_pool().in_flight() > 0 {
+            let _ = event_tx.try_send(crate::event::Event::LinkWriterReady);
+        }
 
-        let mut result = writer.send_frames(&frames);
+        let mut result = Ok(());
+        if queued.iter().any(|frame| frame.completion.is_some()) {
+            for mut frame in queued {
+                let confirmed = frame.completion.is_some();
+                if frame.completion.as_ref().is_some_and(|c| c.is_finished()) {
+                    result = Err(io::Error::new(
+                        io::ErrorKind::Interrupted,
+                        "transmission cancelled by shutdown",
+                    ));
+                }
+                if result.is_ok() {
+                    result = if frame.completion.is_some() {
+                        writer.send_frame_confirmed(&frame.data)
+                    } else {
+                        writer.send_frame(&frame.data)
+                    };
+                    while result
+                        .as_ref()
+                        .is_err_and(|e| e.kind() == io::ErrorKind::WouldBlock)
+                    {
+                        if frame.completion.as_ref().is_some_and(|c| c.is_finished()) {
+                            result = Err(io::Error::new(
+                                io::ErrorKind::Interrupted,
+                                "transmission cancelled by shutdown",
+                            ));
+                            break;
+                        }
+                        thread::sleep(Duration::from_millis(1));
+                        result = writer.flush();
+                    }
+                }
+                if let Some(completion) = frame.completion.take() {
+                    completion.finish(
+                        result.as_ref().map(|_| ()).map_err(|e| {
+                            crate::link_send::LinkSendError::WriteFailed(e.to_string())
+                        }),
+                    );
+                }
+                // Packet-level policy/validation errors do not imply a broken
+                // connection (e.g. a Local client that temporarily holds TX).
+                if confirmed
+                    && result.as_ref().is_err_and(|error| {
+                        matches!(
+                            error.kind(),
+                            io::ErrorKind::PermissionDenied
+                                | io::ErrorKind::InvalidInput
+                                | io::ErrorKind::Unsupported
+                        )
+                    })
+                {
+                    result = Ok(());
+                }
+            }
+        } else {
+            let frames: Vec<_> = queued.into_iter().map(|frame| frame.data).collect();
+            result = writer.send_frames(&frames);
+        }
         while result
             .as_ref()
             .is_err_and(|error| error.kind() == io::ErrorKind::WouldBlock)
@@ -560,6 +672,9 @@ fn async_writer_loop(
 
         if let Some(control) = &metrics.egress_control {
             control.release(reserved_bytes);
+        }
+        if event_tx.link_send_pool().in_flight() > 0 {
+            let _ = event_tx.try_send(crate::event::Event::LinkWriterReady);
         }
 
         if let Err(err) = result {
@@ -942,6 +1057,75 @@ mod tests {
     struct BlockingWriter {
         entered_tx: mpsc::Sender<()>,
         release_rx: mpsc::Receiver<()>,
+    }
+
+    #[test]
+    fn confirmed_writer_waits_for_flush_and_reports_write_failures() {
+        use crate::link_send::{Completion, LinkSendError, SendPool};
+        use futures::FutureExt;
+        struct FlushWriter {
+            entered: mpsc::Sender<()>,
+            release: mpsc::Receiver<()>,
+            writes: Arc<AtomicUsize>,
+        }
+        impl Writer for FlushWriter {
+            fn send_frame(&mut self, _: &[u8]) -> io::Result<()> {
+                self.writes.fetch_add(1, Ordering::SeqCst);
+                Err(io::ErrorKind::WouldBlock.into())
+            }
+            fn flush(&mut self) -> io::Result<()> {
+                self.entered.send(()).unwrap();
+                self.release.recv().unwrap();
+                Ok(())
+            }
+        }
+        let (event_tx, _rx) = crate::event::channel();
+        let (entered, entered_rx) = mpsc::channel();
+        let (release_tx, release) = mpsc::channel();
+        let writes = Arc::new(AtomicUsize::new(0));
+        let pool = SendPool::new(1);
+        let (completion, mut receipt) = Completion::new(pool.try_acquire().unwrap());
+        let (mut writer, _) = wrap_async_writer(
+            Box::new(FlushWriter {
+                entered,
+                release,
+                writes: writes.clone(),
+            }),
+            InterfaceId(999),
+            "flush test",
+            event_tx.clone(),
+            1,
+        );
+        writer
+            .enqueue_confirmed(b"once", &mut Some(completion))
+            .unwrap();
+        entered_rx.recv_timeout(Duration::from_secs(2)).unwrap();
+        assert!((&mut receipt).now_or_never().is_none());
+        release_tx.send(()).unwrap();
+        receipt.wait().unwrap();
+        assert_eq!(
+            writes.load(Ordering::SeqCst),
+            1,
+            "flush must not resubmit the frame"
+        );
+
+        let (completion, receipt) = Completion::new(pool.try_acquire().unwrap());
+        let (mut writer, _) = wrap_async_writer(
+            Box::new(FailingWriter {
+                shutdown_called: Arc::new(AtomicBool::new(false)),
+            }),
+            InterfaceId(998),
+            "failure test",
+            event_tx,
+            1,
+        );
+        writer
+            .enqueue_confirmed(b"fail", &mut Some(completion))
+            .unwrap();
+        assert_eq!(
+            receipt.wait(),
+            Err(LinkSendError::WriteFailed("boom".into()))
+        );
     }
 
     impl Writer for BlockingWriter {

--- a/rns-net/src/interface/rnode/mod.rs
+++ b/rns-net/src/interface/rnode/mod.rs
@@ -207,6 +207,7 @@ pub fn lora_airtime_profile(sub: &RNodeSubConfig) -> AirtimeProfile {
 /// Writer for a specific RNode subinterface.
 /// Wraps a shared serial writer with subinterface-specific data framing.
 struct RNodeSubWriter {
+    confirmed_pending: Option<Vec<u8>>,
     writer: Arc<Mutex<Transport>>,
     index: u8,
     flow_control: bool,
@@ -227,6 +228,7 @@ fn make_sub_writer(
     multi: bool,
 ) -> Box<dyn Writer> {
     Box::new(RNodeSubWriter {
+        confirmed_pending: None,
         writer,
         index,
         flow_control,
@@ -236,6 +238,31 @@ fn make_sub_writer(
 }
 
 impl Writer for RNodeSubWriter {
+    fn send_frame_confirmed(&mut self, data: &[u8]) -> io::Result<()> {
+        if !self.flow_control {
+            return self.send_frame(data);
+        }
+        self.confirmed_pending = Some(if self.multi {
+            rnode_kiss::rnode_multi_data_frame(self.index, data)
+        } else {
+            rnode_kiss::rnode_data_frame(self.index, data)
+        });
+        self.flush()
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        if self.confirmed_pending.is_none() {
+            return Ok(());
+        }
+        let mut state = lock_or_recover(&self.flow_state, "rnode flow state");
+        if !state.ready || !state.queue.is_empty() {
+            return Err(io::ErrorKind::WouldBlock.into());
+        }
+        state.ready = false;
+        drop(state);
+        lock_or_recover(&self.writer, "rnode shared writer")
+            .write_all(&self.confirmed_pending.take().unwrap())
+    }
     fn send_frame(&mut self, data: &[u8]) -> io::Result<()> {
         let frame = if self.multi {
             rnode_kiss::rnode_multi_data_frame(self.index, data)
@@ -1385,6 +1412,7 @@ mod tests {
         }));
 
         let mut sub_writer = RNodeSubWriter {
+            confirmed_pending: None,
             writer: shared_writer.clone(),
             index: 0,
             flow_control: true,
@@ -1424,6 +1452,41 @@ mod tests {
     }
 
     #[test]
+    fn confirmed_rnode_frame_waits_for_ready_and_flushes_once() {
+        let (master_fd, slave_fd) = open_pty_pair().unwrap();
+        let mut master = unsafe { transport_from_raw_fd(master_fd) };
+        let state = Arc::new(Mutex::new(SubFlowState {
+            ready: false,
+            queue: std::collections::VecDeque::new(),
+        }));
+        let mut writer = RNodeSubWriter {
+            confirmed_pending: None,
+            writer: Arc::new(Mutex::new(unsafe { transport_from_raw_fd(slave_fd) })),
+            index: 0,
+            flow_control: true,
+            flow_state: state.clone(),
+            multi: false,
+        };
+        assert_eq!(
+            writer
+                .send_frame_confirmed(b"confirmed")
+                .unwrap_err()
+                .kind(),
+            io::ErrorKind::WouldBlock
+        );
+        assert!(state.lock().unwrap().queue.is_empty());
+        assert!(!poll_read(master.as_raw_fd(), 20));
+        state.lock().unwrap().ready = true;
+        Writer::flush(&mut writer).unwrap();
+        let expected = rnode_kiss::rnode_data_frame(0, b"confirmed");
+        let mut actual = vec![0; expected.len()];
+        master.read_exact(&mut actual).unwrap();
+        assert_eq!(actual, expected);
+        Writer::flush(&mut writer).unwrap();
+        assert!(!poll_read(master.as_raw_fd(), 20));
+    }
+
+    #[test]
     fn rnode_snr_metadata_does_not_depend_on_rssi() {
         let mut last_rssi = None;
         let mut last_snr = None;
@@ -1451,6 +1514,7 @@ mod tests {
         }));
 
         let mut sub_writer = RNodeSubWriter {
+            confirmed_pending: None,
             writer: shared_writer,
             index: 1, // subinterface 1
             flow_control: false,

--- a/rns-net/src/interface/weave.rs
+++ b/rns-net/src/interface/weave.rs
@@ -669,6 +669,12 @@ fn hex(bytes: &[u8]) -> String {
 pub struct WeaveFactory;
 struct ParentWriter;
 impl Writer for ParentWriter {
+    fn send_frame_confirmed(&mut self, _data: &[u8]) -> io::Result<()> {
+        Err(io::Error::new(
+            io::ErrorKind::Unsupported,
+            "Weave parent is not a transmitting peer",
+        ))
+    }
     fn send_frame(&mut self, _data: &[u8]) -> io::Result<()> {
         Ok(())
     }

--- a/rns-net/src/lib.rs
+++ b/rns-net/src/lib.rs
@@ -11,6 +11,7 @@ pub mod common;
 pub mod event;
 pub mod hdlc;
 pub mod kiss;
+pub mod link_send;
 pub mod logging;
 pub mod rnode_kiss;
 pub use common::time;
@@ -104,6 +105,7 @@ pub use interface::{
     InterfaceConfigData, InterfaceFactory, StartContext, StartResult, SubInterface,
 };
 pub use link_manager::{LinkManager, LinkManagerAction, RequestFailure, RequestResponse};
+pub use link_send::{LinkSendError, LinkSendReceipt};
 pub use management::ManagementConfig;
 pub use node::{ChannelSendError, IfacConfig, InterfaceConfig, NodeConfig, RnsNode, SendError};
 #[cfg(feature = "hooks")]

--- a/rns-net/src/lib.rs
+++ b/rns-net/src/lib.rs
@@ -106,6 +106,9 @@ pub use interface::{
 };
 pub use link_manager::{LinkManager, LinkManagerAction, RequestFailure, RequestResponse};
 pub use link_send::{LinkSendError, LinkSendReceipt};
+pub use link_send::{
+    LinkSendError as TransmissionError, LinkSendReceipt as TransmissionReceipt, PacketSendReceipt,
+};
 pub use management::ManagementConfig;
 pub use node::{ChannelSendError, IfacConfig, InterfaceConfig, NodeConfig, RnsNode, SendError};
 #[cfg(feature = "hooks")]

--- a/rns-net/src/link_send.rs
+++ b/rns-net/src/link_send.rs
@@ -1,0 +1,358 @@
+//! Runtime-independent Link transmission completion and bounded admission.
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::{Arc, Mutex, Weak};
+use std::task::{Context, Poll, Waker};
+
+use futures::channel::oneshot;
+
+/// A local send failure. Success never implies acknowledgement by the peer.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum LinkSendError {
+    QueueFull,
+    DriverStopped,
+    Interrupted,
+    Draining,
+    InvalidPacket(crate::event::LinkDatagramError),
+    NoRoute,
+    Rejected,
+    InterfaceUnavailable,
+    WriteFailed(String),
+}
+
+impl std::fmt::Display for LinkSendError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::QueueFull => f.write_str("outbound queue is full"),
+            Self::DriverStopped => f.write_str("driver stopped before transmission completed"),
+            Self::Interrupted => f.write_str("transmission interrupted before completion"),
+            Self::Draining => f.write_str("node is draining"),
+            Self::InvalidPacket(error) => write!(f, "{error}"),
+            Self::NoRoute => f.write_str("no interface route for Link"),
+            Self::Rejected => f.write_str("outbound packet rejected by routing or policy"),
+            Self::InterfaceUnavailable => f.write_str("outbound interface is unavailable"),
+            Self::WriteFailed(error) => write!(f, "interface write failed: {error}"),
+        }
+    }
+}
+impl std::error::Error for LinkSendError {}
+
+/// Await this receipt to learn whether the interface finished writing the packet.
+/// Obtaining a receipt means admission only; it is not a transmission result.
+/// Dropping a receipt does not cancel an admitted send.
+#[must_use = "await the receipt (or call wait) to observe transmission completion"]
+pub struct LinkSendReceipt(oneshot::Receiver<Result<(), LinkSendError>>);
+
+impl Future for LinkSendReceipt {
+    type Output = Result<(), LinkSendError>;
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        Pin::new(&mut self.0)
+            .poll(cx)
+            .map(|result| result.unwrap_or(Err(LinkSendError::Interrupted)))
+    }
+}
+
+impl LinkSendReceipt {
+    /// Blocking counterpart for synchronous callers. Do not call from a driver callback.
+    pub fn wait(self) -> Result<(), LinkSendError> {
+        futures::executor::block_on(self)
+    }
+}
+
+#[derive(Default)]
+pub(crate) struct Waiter(Mutex<Option<Waker>>);
+
+impl Waiter {
+    pub(crate) fn register(&self, cx: &Context<'_>) {
+        *self.0.lock().unwrap() = Some(cx.waker().clone());
+    }
+    pub(crate) fn wake(&self) {
+        let waker = self.0.lock().unwrap().take();
+        if let Some(waker) = waker {
+            waker.wake();
+        }
+    }
+}
+
+struct PoolState {
+    used: usize,
+    closed: bool,
+    waiters: Vec<Weak<Waiter>>,
+    completions: Vec<Weak<CompletionState>>,
+}
+
+pub(crate) struct SendPool {
+    capacity: usize,
+    state: Mutex<PoolState>,
+}
+
+impl SendPool {
+    pub(crate) fn new(capacity: usize) -> Arc<Self> {
+        Arc::new(Self {
+            capacity: capacity.max(1),
+            state: Mutex::new(PoolState {
+                used: 0,
+                closed: false,
+                waiters: Vec::new(),
+                completions: Vec::new(),
+            }),
+        })
+    }
+
+    pub(crate) fn try_acquire(self: &Arc<Self>) -> Result<Permit, LinkSendError> {
+        let mut state = self.state.lock().unwrap();
+        if state.closed {
+            return Err(LinkSendError::DriverStopped);
+        }
+        if state.used == self.capacity {
+            return Err(LinkSendError::QueueFull);
+        }
+        state.used += 1;
+        Ok(Permit(self.clone()))
+    }
+
+    pub(crate) async fn acquire(self: &Arc<Self>) -> Result<Permit, LinkSendError> {
+        let waiter = Arc::new(Waiter::default());
+        {
+            let mut state = self.state.lock().unwrap();
+            state.waiters.retain(|waiter| waiter.strong_count() > 0);
+            state.waiters.push(Arc::downgrade(&waiter));
+        }
+        futures::future::poll_fn(|cx| {
+            waiter.register(cx);
+            match self.try_acquire() {
+                Err(LinkSendError::QueueFull) => Poll::Pending,
+                result => Poll::Ready(result),
+            }
+        })
+        .await
+    }
+
+    pub(crate) fn close(&self) {
+        let (waiters, completions) = {
+            let mut state = self.state.lock().unwrap();
+            state.closed = true;
+            (
+                std::mem::take(&mut state.waiters),
+                std::mem::take(&mut state.completions),
+            )
+        };
+        for waiter in waiters.into_iter().filter_map(|w| w.upgrade()) {
+            waiter.wake();
+        }
+        for completion in completions.into_iter().filter_map(|w| w.upgrade()) {
+            completion.finish(Err(LinkSendError::DriverStopped));
+        }
+    }
+
+    pub(crate) fn in_flight(&self) -> usize {
+        self.state.lock().unwrap().used
+    }
+}
+
+pub(crate) struct Permit(Arc<SendPool>);
+impl Drop for Permit {
+    fn drop(&mut self) {
+        let waiters = {
+            let mut state = self.0.state.lock().unwrap();
+            state.used -= 1;
+            state.waiters.retain(|waiter| waiter.strong_count() > 0);
+            state.waiters.clone()
+        };
+        for waiter in waiters.into_iter().filter_map(|w| w.upgrade()) {
+            waiter.wake();
+        }
+    }
+}
+
+/// Internal writer completion token. Dropping it reports an interrupted send.
+#[doc(hidden)]
+pub struct Completion {
+    state: Arc<CompletionState>,
+    _permit: Permit,
+}
+
+struct CompletionState(Mutex<Option<oneshot::Sender<Result<(), LinkSendError>>>>);
+impl CompletionState {
+    fn finish(&self, result: Result<(), LinkSendError>) {
+        let tx = self.0.lock().unwrap().take();
+        if let Some(tx) = tx {
+            let _ = tx.send(result);
+        }
+    }
+}
+
+impl Completion {
+    pub(crate) fn new(permit: Permit) -> (Self, LinkSendReceipt) {
+        let (tx, rx) = oneshot::channel();
+        let completion = Arc::new(CompletionState(Mutex::new(Some(tx))));
+        {
+            let mut pool = permit.0.state.lock().unwrap();
+            pool.completions.retain(|w| w.strong_count() > 0);
+            if pool.closed {
+                drop(pool);
+                completion.finish(Err(LinkSendError::DriverStopped));
+            } else {
+                pool.completions.push(Arc::downgrade(&completion));
+            }
+        }
+        (
+            Self {
+                state: completion,
+                _permit: permit,
+            },
+            LinkSendReceipt(rx),
+        )
+    }
+    pub(crate) fn finish(self, result: Result<(), LinkSendError>) {
+        let Self { state, _permit } = self;
+        drop(_permit);
+        state.finish(result);
+    }
+    pub(crate) fn is_finished(&self) -> bool {
+        self.state.0.lock().unwrap().is_none()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use futures::{executor::block_on, FutureExt};
+
+    #[test]
+    fn node_try_rejects_full_capacity_and_async_send_wakes_without_blocking() {
+        use crate::event::Event;
+        use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
+        struct WakeCount(AtomicUsize);
+        impl futures::task::ArcWake for WakeCount {
+            fn wake_by_ref(this: &Arc<Self>) {
+                this.0.fetch_add(1, Ordering::SeqCst);
+            }
+        }
+        let (tx, rx) = crate::event::channel_with_capacity(1);
+        let node = crate::RnsNode::from_parts(
+            tx.clone(),
+            std::thread::spawn(|| {}),
+            None,
+            Arc::new(AtomicU64::new(1000)),
+        );
+        let receipt = node.try_send_on_link([1; 16], vec![1], 0).unwrap();
+        let first = match rx.try_recv().unwrap() {
+            Event::SendLinkTracked { completion, .. } => completion,
+            _ => panic!("expected a tracked send"),
+        };
+        assert!(matches!(
+            node.try_send_on_link([1; 16], vec![2], 0),
+            Err(LinkSendError::QueueFull)
+        ));
+        let mut pending = Box::pin(node.send_on_link([1; 16], vec![2], 0));
+        let wakes = Arc::new(WakeCount(AtomicUsize::new(0)));
+        let waker = futures::task::waker(wakes.clone());
+        let mut cx = Context::from_waker(&waker);
+        assert!(pending.as_mut().poll(&mut cx).is_pending());
+        assert!(
+            rx.try_recv().is_err(),
+            "capacity wait must not enqueue prematurely"
+        );
+        first.finish(Ok(()));
+        receipt.wait().unwrap();
+        assert!(
+            wakes.0.load(Ordering::SeqCst) > 0,
+            "capacity release must wake the task"
+        );
+        assert!(pending.as_mut().poll(&mut cx).is_pending());
+        let second = match rx.try_recv().unwrap() {
+            Event::SendLinkTracked { completion, .. } => completion,
+            _ => panic!("expected a tracked send"),
+        };
+        second.finish(Ok(()));
+        assert_eq!(pending.as_mut().poll(&mut cx), Poll::Ready(Ok(())));
+        drop(pending);
+
+        // A full *driver* event queue also makes try return immediately.
+        tx.try_send(Event::Tick).unwrap();
+        assert!(matches!(
+            node.try_send_on_link([1; 16], vec![3], 0),
+            Err(LinkSendError::QueueFull)
+        ));
+        let mut cancelled = Box::pin(node.send_on_link([1; 16], vec![3], 0));
+        assert!(cancelled.as_mut().poll(&mut cx).is_pending());
+        drop(cancelled);
+        assert_eq!(tx.link_send_pool().in_flight(), 0);
+        assert!(matches!(rx.try_recv(), Ok(Event::Tick)));
+        assert!(
+            rx.try_recv().is_err(),
+            "cancelled admission must not send later"
+        );
+        drop(rx);
+        node.shutdown();
+    }
+
+    #[test]
+    fn capacity_waits_for_transmission_not_receipt_creation() {
+        let pool = SendPool::new(1);
+        let (completion, mut receipt) = Completion::new(pool.try_acquire().unwrap());
+        assert!(matches!(pool.try_acquire(), Err(LinkSendError::QueueFull)));
+        assert!((&mut receipt).now_or_never().is_none());
+        let mut waiting = Box::pin(pool.acquire());
+        assert!(waiting.as_mut().now_or_never().is_none());
+        completion.finish(Ok(()));
+        receipt.wait().unwrap();
+        let permit = block_on(waiting).unwrap();
+        assert!(matches!(pool.try_acquire(), Err(LinkSendError::QueueFull)));
+        drop(permit);
+        assert!(pool.try_acquire().is_ok());
+    }
+
+    #[test]
+    fn shutdown_resolves_in_flight_receipts_and_capacity_waiters() {
+        let pool = SendPool::new(1);
+        let (completion, receipt) = Completion::new(pool.try_acquire().unwrap());
+        let mut waiting = Box::pin(pool.acquire());
+        assert!(waiting.as_mut().now_or_never().is_none());
+        pool.close();
+        assert_eq!(receipt.wait(), Err(LinkSendError::DriverStopped));
+        assert!(matches!(
+            block_on(waiting),
+            Err(LinkSendError::DriverStopped)
+        ));
+        // A delayed worker cannot overwrite the shutdown result.
+        completion.finish(Ok(()));
+    }
+
+    #[test]
+    fn dropping_receipt_does_not_release_an_in_flight_slot() {
+        let pool = SendPool::new(1);
+        let (completion, receipt) = Completion::new(pool.try_acquire().unwrap());
+        drop(receipt);
+        assert!(matches!(pool.try_acquire(), Err(LinkSendError::QueueFull)));
+        drop(completion);
+        assert!(pool.try_acquire().is_ok());
+    }
+
+    #[test]
+    fn both_node_apis_report_the_same_invalid_link_error() {
+        struct Callbacks;
+        impl crate::Callbacks for Callbacks {
+            fn on_announce(&mut self, _: crate::AnnouncedIdentity) {}
+            fn on_path_updated(&mut self, _: crate::DestHash, _: u8) {}
+            fn on_local_delivery(&mut self, _: crate::DestHash, _: Vec<u8>, _: crate::PacketHash) {}
+        }
+        let node =
+            crate::RnsNode::start(crate::NodeConfig::default(), Box::new(Callbacks)).unwrap();
+        let expected = Err(LinkSendError::InvalidPacket(
+            crate::event::LinkDatagramError::LinkNotFound,
+        ));
+        assert_eq!(
+            block_on(node.send_on_link([0x42; 16], vec![1], 0)),
+            expected
+        );
+        assert_eq!(
+            node.try_send_on_link([0x42; 16], vec![1], 0)
+                .unwrap()
+                .wait(),
+            expected
+        );
+        node.shutdown();
+    }
+}

--- a/rns-net/src/link_send.rs
+++ b/rns-net/src/link_send.rs
@@ -1,4 +1,4 @@
-//! Runtime-independent Link transmission completion and bounded admission.
+//! Runtime-independent transmission completion and bounded admission.
 use std::future::Future;
 use std::pin::Pin;
 use std::sync::{Arc, Mutex, Weak};
@@ -14,6 +14,7 @@ pub enum LinkSendError {
     Interrupted,
     Draining,
     InvalidPacket(crate::event::LinkDatagramError),
+    PacketBuildFailed,
     NoRoute,
     Rejected,
     InterfaceUnavailable,
@@ -28,7 +29,8 @@ impl std::fmt::Display for LinkSendError {
             Self::Interrupted => f.write_str("transmission interrupted before completion"),
             Self::Draining => f.write_str("node is draining"),
             Self::InvalidPacket(error) => write!(f, "{error}"),
-            Self::NoRoute => f.write_str("no interface route for Link"),
+            Self::PacketBuildFailed => f.write_str("failed to build or encrypt outbound packet"),
+            Self::NoRoute => f.write_str("no outgoing interface route"),
             Self::Rejected => f.write_str("outbound packet rejected by routing or policy"),
             Self::InterfaceUnavailable => f.write_str("outbound interface is unavailable"),
             Self::WriteFailed(error) => write!(f, "interface write failed: {error}"),
@@ -37,7 +39,7 @@ impl std::fmt::Display for LinkSendError {
 }
 impl std::error::Error for LinkSendError {}
 
-/// Await this receipt to learn whether the interface finished writing the packet.
+/// Await this receipt to learn whether all selected interfaces finished writing.
 /// Obtaining a receipt means admission only; it is not a transmission result.
 /// Dropping a receipt does not cancel an admitted send.
 #[must_use = "await the receipt (or call wait) to observe transmission completion"]
@@ -56,6 +58,33 @@ impl LinkSendReceipt {
     /// Blocking counterpart for synchronous callers. Do not call from a driver callback.
     pub fn wait(self) -> Result<(), LinkSendError> {
         futures::executor::block_on(self)
+    }
+}
+
+/// A packet's hash is available immediately for proof tracking, but successful
+/// transmission is reported only when this receipt resolves. Failure may follow
+/// partial transmission; neither the hash nor success promises remote delivery.
+#[must_use = "await the receipt (or call wait) to observe transmission completion"]
+pub struct PacketSendReceipt {
+    pub(crate) completion: LinkSendReceipt,
+    pub(crate) hash: rns_core::types::PacketHash,
+}
+impl PacketSendReceipt {
+    pub fn packet_hash(&self) -> rns_core::types::PacketHash {
+        self.hash
+    }
+    /// Blocking completion wait. Do not call from a driver callback.
+    pub fn wait(self) -> Result<rns_core::types::PacketHash, LinkSendError> {
+        futures::executor::block_on(self)
+    }
+}
+impl Future for PacketSendReceipt {
+    type Output = Result<rns_core::types::PacketHash, LinkSendError>;
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let hash = self.hash;
+        Pin::new(&mut self.completion)
+            .poll(cx)
+            .map(|r| r.map(|()| hash))
     }
 }
 
@@ -242,12 +271,15 @@ impl Drop for Permit {
 #[doc(hidden)]
 pub struct Completion {
     state: Arc<CompletionState>,
-    _permit: Permit,
+    settled: bool,
 }
 
 struct CompletionData {
     tx: oneshot::Sender<Result<(), LinkSendError>>,
     tracking: Option<SendTracking>,
+    permit: Permit,
+    remaining: usize,
+    error: Option<LinkSendError>,
 }
 struct CompletionState(Mutex<Option<CompletionData>>);
 impl Drop for CompletionState {
@@ -261,13 +293,13 @@ impl CompletionState {
         let data = self.0.lock().unwrap().take();
         if let Some(data) = data {
             drop(data.tracking);
+            drop(data.permit);
             let _ = data.tx.send(result);
         }
     }
 }
 
 impl Completion {
-    #[cfg(test)]
     pub(crate) fn new(permit: Permit) -> (Self, LinkSendReceipt) {
         Self::new_inner(permit, None)
     }
@@ -278,12 +310,16 @@ impl Completion {
 
     fn new_inner(permit: Permit, tracking: Option<SendTracking>) -> (Self, LinkSendReceipt) {
         let (tx, rx) = oneshot::channel();
+        let pool = permit.0.clone();
         let completion = Arc::new(CompletionState(Mutex::new(Some(CompletionData {
             tx,
             tracking,
+            permit,
+            remaining: 1,
+            error: None,
         }))));
         {
-            let mut pool = permit.0.state.lock().unwrap();
+            let mut pool = pool.state.lock().unwrap();
             pool.completions.retain(|w| w.strong_count() > 0);
             if pool.closed {
                 drop(pool);
@@ -295,15 +331,47 @@ impl Completion {
         (
             Self {
                 state: completion,
-                _permit: permit,
+                settled: false,
             },
             LinkSendReceipt(rx),
         )
     }
-    pub(crate) fn finish(self, result: Result<(), LinkSendError>) {
-        let Self { state, _permit } = self;
-        drop(_permit);
-        state.finish(result);
+    pub(crate) fn finish(mut self, result: Result<(), LinkSendError>) {
+        self.settle(result);
+    }
+
+    /// Each selected interface gets a branch. The permit and receipt remain
+    /// live until every branch settles, even if one branch fails early.
+    pub(crate) fn branch(&self) -> Self {
+        if let Some(data) = self.state.0.lock().unwrap().as_mut() {
+            data.remaining += 1;
+        }
+        Self {
+            state: self.state.clone(),
+            settled: false,
+        }
+    }
+
+    fn settle(&mut self, result: Result<(), LinkSendError>) {
+        self.settled = true;
+        let final_data = {
+            let mut guard = self.state.0.lock().unwrap();
+            let Some(data) = guard.as_mut() else { return };
+            if data.error.is_none() {
+                data.error = result.err();
+            }
+            data.remaining -= 1;
+            if data.remaining == 0 {
+                guard.take()
+            } else {
+                None
+            }
+        };
+        if let Some(data) = final_data {
+            drop(data.tracking);
+            drop(data.permit);
+            let _ = data.tx.send(data.error.map_or(Ok(()), Err));
+        }
     }
     pub(crate) fn is_finished(&self) -> bool {
         self.state.0.lock().unwrap().is_none()
@@ -318,10 +386,153 @@ impl Completion {
     }
 }
 
+impl Drop for Completion {
+    fn drop(&mut self) {
+        if !self.settled {
+            self.settle(Err(LinkSendError::Interrupted));
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use futures::{executor::block_on, FutureExt};
+
+    #[test]
+    fn fanout_keeps_capacity_until_all_writes_settle() {
+        let pool = SendPool::new(1);
+        let (completion, mut receipt) = Completion::new(pool.try_acquire().unwrap());
+        let first = completion.branch();
+        let last = completion.branch();
+        completion.finish(Ok(()));
+        first.finish(Err(LinkSendError::WriteFailed("first failed".into())));
+        assert!((&mut receipt).now_or_never().is_none());
+        assert!(matches!(pool.try_acquire(), Err(LinkSendError::QueueFull)));
+        last.finish(Ok(()));
+        assert_eq!(
+            receipt.wait(),
+            Err(LinkSendError::WriteFailed("first failed".into()))
+        );
+        assert_eq!(pool.in_flight(), 0);
+
+        let (completion, receipt) = Completion::new(pool.try_acquire().unwrap());
+        let child = completion.branch();
+        completion.finish(Ok(()));
+        drop(child);
+        assert_eq!(receipt.wait(), Err(LinkSendError::Interrupted));
+        assert_eq!(pool.in_flight(), 0);
+
+        let (completion, receipt) = Completion::new(pool.try_acquire().unwrap());
+        let child = completion.branch();
+        pool.close();
+        assert_eq!(receipt.wait(), Err(LinkSendError::DriverStopped));
+        assert_eq!(pool.in_flight(), 0);
+        drop((completion, child));
+    }
+
+    #[test]
+    fn packet_and_announce_admission_is_bounded_and_runtime_independent() {
+        use crate::event::Event;
+        let (tx, rx) = crate::event::channel_with_capacity(1);
+        let node = crate::RnsNode::from_parts(
+            tx.clone(),
+            std::thread::spawn(|| {}),
+            None,
+            Arc::new(std::sync::atomic::AtomicU64::new(1000)),
+        );
+        let dest = crate::Destination::plain("confirmed", &["packet"]);
+        let identity = rns_crypto::identity::Identity::new(&mut rns_crypto::OsRng);
+        let announce_dest = crate::Destination::single_in(
+            "confirmed",
+            &["announce"],
+            crate::IdentityHash(*identity.hash()),
+        );
+        drop(node.announce(&announce_dest, &identity, None));
+        assert!(
+            rx.try_recv().is_err(),
+            "unpolled sends must have no side effects"
+        );
+        tx.send(Event::Tick).unwrap();
+        assert!(matches!(
+            node.try_announce(&announce_dest, &identity, None),
+            Err(LinkSendError::QueueFull)
+        ));
+        let mut cancelled = Box::pin(node.announce(&announce_dest, &identity, None));
+        assert!(cancelled.as_mut().now_or_never().is_none());
+        drop(cancelled);
+        assert_eq!(tx.link_send_pool().in_flight(), 0);
+        assert!(matches!(rx.try_recv(), Ok(Event::Tick)));
+        assert!(
+            rx.try_recv().is_err(),
+            "cancelled admission must not update replay state"
+        );
+        let receipt = node.try_send_packet(&dest, b"first").unwrap();
+        let hash = receipt.packet_hash();
+        let Event::SendOutboundTracked {
+            completion: first, ..
+        } = rx.try_recv().unwrap()
+        else {
+            panic!("expected tracked packet")
+        };
+        assert!(matches!(
+            node.try_announce(&announce_dest, &identity, None),
+            Err(LinkSendError::QueueFull)
+        ));
+        let mut announce = Box::pin(node.announce(&announce_dest, &identity, None));
+        assert!(announce.as_mut().now_or_never().is_none());
+        assert!(rx.try_recv().is_err());
+        first.finish(Ok(()));
+        assert_eq!(receipt.wait().unwrap(), hash);
+        assert!(announce.as_mut().now_or_never().is_none());
+        let Event::SendOutboundTracked {
+            completion, replay, ..
+        } = rx.try_recv().unwrap()
+        else {
+            panic!("expected tracked announce")
+        };
+        assert_eq!(replay.unwrap().dest_hash, announce_dest.hash.0);
+        assert!(matches!(
+            node.try_send_packet(&dest, b"full"),
+            Err(LinkSendError::QueueFull)
+        ));
+        completion.finish(Ok(()));
+        block_on(announce).unwrap();
+        let receipt = node.try_announce(&announce_dest, &identity, None).unwrap();
+        let Event::SendOutboundTracked { completion, .. } = rx.try_recv().unwrap() else {
+            panic!("expected tracked announce")
+        };
+        completion.finish(Ok(()));
+        receipt.wait().unwrap();
+        let mut packet = Box::pin(node.send_packet(&dest, b"async"));
+        assert!(packet.as_mut().now_or_never().is_none());
+        let Event::SendOutboundTracked {
+            completion, raw, ..
+        } = rx.try_recv().unwrap()
+        else {
+            panic!("expected tracked packet")
+        };
+        let hash = rns_core::types::PacketHash(
+            rns_core::packet::RawPacket::unpack(&raw)
+                .unwrap()
+                .packet_hash,
+        );
+        completion.finish(Ok(()));
+        assert_eq!(block_on(packet).unwrap(), hash);
+        assert!(
+            tx.link_send_pool().snapshot().is_empty(),
+            "non-Link sends must not affect per-Link counts"
+        );
+        drop(rx);
+        assert!(matches!(
+            node.try_send_packet(&dest, b"stopped"),
+            Err(LinkSendError::DriverStopped)
+        ));
+        assert_eq!(
+            block_on(node.announce(&announce_dest, &identity, None)),
+            Err(LinkSendError::DriverStopped)
+        );
+    }
 
     #[test]
     fn per_link_counts_cover_failure_shutdown_and_receipt_cancellation() {
@@ -544,6 +755,53 @@ mod tests {
                 .unwrap()
                 .wait(),
             expected
+        );
+        let dest = crate::Destination::plain("confirmed", &["no_route"]);
+        assert_eq!(
+            block_on(node.send_packet(&dest, b"data")),
+            Err(LinkSendError::NoRoute)
+        );
+        assert_eq!(
+            node.try_send_packet(&dest, b"data").unwrap().wait(),
+            Err(LinkSendError::NoRoute)
+        );
+        let identity = rns_crypto::identity::Identity::new(&mut rns_crypto::OsRng);
+        let announce_dest = crate::Destination::single_in(
+            "confirmed",
+            &["announce"],
+            crate::IdentityHash(*identity.hash()),
+        );
+        assert_eq!(
+            block_on(node.announce(&announce_dest, &identity, None)),
+            Err(LinkSendError::NoRoute)
+        );
+        assert_eq!(
+            node.try_announce(&announce_dest, &identity, None)
+                .unwrap()
+                .wait(),
+            Err(LinkSendError::NoRoute)
+        );
+        let oversized = vec![0; rns_core::constants::MTU * 2];
+        assert_eq!(
+            block_on(node.send_packet(&dest, &oversized)),
+            Err(LinkSendError::PacketBuildFailed)
+        );
+        assert!(matches!(
+            node.try_send_packet(&dest, &oversized),
+            Err(LinkSendError::PacketBuildFailed)
+        ));
+        node.begin_drain(std::time::Duration::from_secs(30))
+            .unwrap();
+        node.drain_status().unwrap();
+        assert_eq!(
+            block_on(node.send_packet(&dest, b"data")),
+            Err(LinkSendError::Draining)
+        );
+        assert_eq!(
+            node.try_announce(&announce_dest, &identity, None)
+                .unwrap()
+                .wait(),
+            Err(LinkSendError::Draining)
         );
         node.shutdown();
     }

--- a/rns-net/src/link_send.rs
+++ b/rns-net/src/link_send.rs
@@ -79,6 +79,58 @@ struct PoolState {
     closed: bool,
     waiters: Vec<Weak<Waiter>>,
     completions: Vec<Weak<CompletionState>>,
+    links: std::collections::HashMap<[u8; 16], SendCounts>,
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub(crate) struct SendCounts {
+    pub pending: usize,
+    pub waiting: usize,
+}
+
+enum SendPhase {
+    Unadmitted,
+    Waiting,
+    Pending,
+}
+
+pub(crate) struct SendTracking {
+    pool: Arc<SendPool>,
+    link_id: [u8; 16],
+    phase: SendPhase,
+}
+
+impl SendTracking {
+    fn admit(&mut self) {
+        let mut state = self.pool.state.lock().unwrap();
+        if state.closed {
+            return;
+        }
+        let counts = state.links.entry(self.link_id).or_default();
+        match self.phase {
+            SendPhase::Waiting => counts.waiting -= 1,
+            SendPhase::Pending => return,
+            SendPhase::Unadmitted => {}
+        }
+        counts.pending += 1;
+        self.phase = SendPhase::Pending;
+    }
+}
+
+impl Drop for SendTracking {
+    fn drop(&mut self) {
+        let mut state = self.pool.state.lock().unwrap();
+        if let Some(counts) = state.links.get_mut(&self.link_id) {
+            match self.phase {
+                SendPhase::Waiting => counts.waiting -= 1,
+                SendPhase::Pending => counts.pending -= 1,
+                SendPhase::Unadmitted => {}
+            }
+            if counts.pending == 0 && counts.waiting == 0 {
+                state.links.remove(&self.link_id);
+            }
+        }
+    }
 }
 
 pub(crate) struct SendPool {
@@ -95,6 +147,7 @@ impl SendPool {
                 closed: false,
                 waiters: Vec::new(),
                 completions: Vec::new(),
+                links: std::collections::HashMap::new(),
             }),
         })
     }
@@ -109,6 +162,25 @@ impl SendPool {
         }
         state.used += 1;
         Ok(Permit(self.clone()))
+    }
+
+    pub(crate) fn track(self: &Arc<Self>, link_id: [u8; 16], waiting: bool) -> SendTracking {
+        let mut state = self.state.lock().unwrap();
+        let phase = if waiting && !state.closed {
+            state.links.entry(link_id).or_default().waiting += 1;
+            SendPhase::Waiting
+        } else {
+            SendPhase::Unadmitted
+        };
+        SendTracking {
+            pool: self.clone(),
+            link_id,
+            phase,
+        }
+    }
+
+    pub(crate) fn snapshot(&self) -> std::collections::HashMap<[u8; 16], SendCounts> {
+        self.state.lock().unwrap().links.clone()
     }
 
     pub(crate) async fn acquire(self: &Arc<Self>) -> Result<Permit, LinkSendError> {
@@ -132,6 +204,7 @@ impl SendPool {
         let (waiters, completions) = {
             let mut state = self.state.lock().unwrap();
             state.closed = true;
+            state.links.clear();
             (
                 std::mem::take(&mut state.waiters),
                 std::mem::take(&mut state.completions),
@@ -172,20 +245,43 @@ pub struct Completion {
     _permit: Permit,
 }
 
-struct CompletionState(Mutex<Option<oneshot::Sender<Result<(), LinkSendError>>>>);
+struct CompletionData {
+    tx: oneshot::Sender<Result<(), LinkSendError>>,
+    tracking: Option<SendTracking>,
+}
+struct CompletionState(Mutex<Option<CompletionData>>);
+impl Drop for CompletionState {
+    fn drop(&mut self) {
+        // Clear counters before waking a receipt whose writer/event vanished.
+        self.finish(Err(LinkSendError::Interrupted));
+    }
+}
 impl CompletionState {
     fn finish(&self, result: Result<(), LinkSendError>) {
-        let tx = self.0.lock().unwrap().take();
-        if let Some(tx) = tx {
-            let _ = tx.send(result);
+        let data = self.0.lock().unwrap().take();
+        if let Some(data) = data {
+            drop(data.tracking);
+            let _ = data.tx.send(result);
         }
     }
 }
 
 impl Completion {
+    #[cfg(test)]
     pub(crate) fn new(permit: Permit) -> (Self, LinkSendReceipt) {
+        Self::new_inner(permit, None)
+    }
+
+    pub(crate) fn new_tracked(permit: Permit, tracking: SendTracking) -> (Self, LinkSendReceipt) {
+        Self::new_inner(permit, Some(tracking))
+    }
+
+    fn new_inner(permit: Permit, tracking: Option<SendTracking>) -> (Self, LinkSendReceipt) {
         let (tx, rx) = oneshot::channel();
-        let completion = Arc::new(CompletionState(Mutex::new(Some(tx))));
+        let completion = Arc::new(CompletionState(Mutex::new(Some(CompletionData {
+            tx,
+            tracking,
+        }))));
         {
             let mut pool = permit.0.state.lock().unwrap();
             pool.completions.retain(|w| w.strong_count() > 0);
@@ -212,12 +308,71 @@ impl Completion {
     pub(crate) fn is_finished(&self) -> bool {
         self.state.0.lock().unwrap().is_none()
     }
+
+    pub(crate) fn admit(&self) {
+        if let Some(data) = self.state.0.lock().unwrap().as_mut() {
+            if let Some(tracking) = data.tracking.as_mut() {
+                tracking.admit();
+            }
+        }
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
     use futures::{executor::block_on, FutureExt};
+
+    #[test]
+    fn per_link_counts_cover_failure_shutdown_and_receipt_cancellation() {
+        let pool = SendPool::new(3);
+        let waiting = pool.track([1; 16], true);
+        let tracking = pool.track([2; 16], true);
+        let (completion, receipt) = Completion::new_tracked(pool.try_acquire().unwrap(), tracking);
+        completion.admit();
+        assert_eq!(
+            pool.snapshot().get(&[1; 16]),
+            Some(&SendCounts {
+                pending: 0,
+                waiting: 1
+            })
+        );
+        assert_eq!(
+            pool.snapshot().get(&[2; 16]),
+            Some(&SendCounts {
+                pending: 1,
+                waiting: 0
+            })
+        );
+        drop(receipt);
+        assert_eq!(
+            pool.snapshot()[&[2; 16]].pending,
+            1,
+            "dropping a receipt does not cancel transmission"
+        );
+        completion.finish(Err(LinkSendError::WriteFailed("broken pipe".into())));
+        assert!(!pool.snapshot().contains_key(&[2; 16]));
+        drop(waiting);
+        assert!(pool.snapshot().is_empty());
+
+        let tracking = pool.track([4; 16], false);
+        let (completion, receipt) = Completion::new_tracked(pool.try_acquire().unwrap(), tracking);
+        completion.admit();
+        drop(completion);
+        assert_eq!(receipt.wait(), Err(LinkSendError::Interrupted));
+        assert!(pool.snapshot().is_empty());
+
+        let tracking = pool.track([3; 16], false);
+        let (completion, receipt) = Completion::new_tracked(pool.try_acquire().unwrap(), tracking);
+        completion.admit();
+        let waiting = pool.track([3; 16], true);
+        pool.close();
+        assert_eq!(receipt.wait(), Err(LinkSendError::DriverStopped));
+        assert!(pool.snapshot().is_empty());
+        drop(waiting);
+        drop(completion);
+        assert!(pool.snapshot().is_empty());
+    }
 
     #[test]
     fn node_try_rejects_full_capacity_and_async_send_wakes_without_blocking() {
@@ -237,6 +392,13 @@ mod tests {
             Arc::new(AtomicU64::new(1000)),
         );
         let receipt = node.try_send_on_link([1; 16], vec![1], 0).unwrap();
+        assert_eq!(
+            tx.link_send_pool().snapshot()[&[1; 16]],
+            SendCounts {
+                pending: 1,
+                waiting: 0
+            }
+        );
         let first = match rx.try_recv().unwrap() {
             Event::SendLinkTracked { completion, .. } => completion,
             _ => panic!("expected a tracked send"),
@@ -250,12 +412,26 @@ mod tests {
         let waker = futures::task::waker(wakes.clone());
         let mut cx = Context::from_waker(&waker);
         assert!(pending.as_mut().poll(&mut cx).is_pending());
+        assert_eq!(
+            tx.link_send_pool().snapshot()[&[1; 16]],
+            SendCounts {
+                pending: 1,
+                waiting: 1
+            }
+        );
         assert!(
             rx.try_recv().is_err(),
             "capacity wait must not enqueue prematurely"
         );
         first.finish(Ok(()));
         receipt.wait().unwrap();
+        assert_eq!(
+            tx.link_send_pool().snapshot()[&[1; 16]],
+            SendCounts {
+                pending: 0,
+                waiting: 1
+            }
+        );
         assert!(
             wakes.0.load(Ordering::SeqCst) > 0,
             "capacity release must wake the task"
@@ -265,7 +441,15 @@ mod tests {
             Event::SendLinkTracked { completion, .. } => completion,
             _ => panic!("expected a tracked send"),
         };
+        assert_eq!(
+            tx.link_send_pool().snapshot()[&[1; 16]],
+            SendCounts {
+                pending: 1,
+                waiting: 0
+            }
+        );
         second.finish(Ok(()));
+        assert!(tx.link_send_pool().snapshot().is_empty());
         assert_eq!(pending.as_mut().poll(&mut cx), Poll::Ready(Ok(())));
         drop(pending);
 
@@ -277,7 +461,15 @@ mod tests {
         ));
         let mut cancelled = Box::pin(node.send_on_link([1; 16], vec![3], 0));
         assert!(cancelled.as_mut().poll(&mut cx).is_pending());
+        assert_eq!(
+            tx.link_send_pool().snapshot()[&[1; 16]],
+            SendCounts {
+                pending: 0,
+                waiting: 1
+            }
+        );
         drop(cancelled);
+        assert!(tx.link_send_pool().snapshot().is_empty());
         assert_eq!(tx.link_send_pool().in_flight(), 0);
         assert!(matches!(rx.try_recv(), Ok(Event::Tick)));
         assert!(

--- a/rns-net/src/node.rs
+++ b/rns-net/src/node.rs
@@ -2171,6 +2171,17 @@ impl RnsNode {
         }
     }
 
+    /// Snapshot one Link, including local send backlog, or None if unknown.
+    pub fn query_link(
+        &self,
+        link_id: [u8; 16],
+    ) -> Result<Option<crate::event::LinkInfoEntry>, SendError> {
+        Ok(self
+            .links()?
+            .into_iter()
+            .find(|link| link.link_id == link_id))
+    }
+
     /// Return the slowest positive bitrate among currently registered interfaces.
     ///
     /// Returns `Ok(None)` when no registered interface advertises a usable
@@ -2646,8 +2657,9 @@ impl RnsNode {
         context: u8,
     ) -> Result<(), crate::link_send::LinkSendError> {
         use crate::link_send::Completion;
+        let tracking = self.tx.link_send_pool().track(link_id, true);
         let permit = self.tx.link_send_pool().acquire().await?;
-        let (completion, receipt) = Completion::new(permit);
+        let (completion, receipt) = Completion::new_tracked(permit, tracking);
         self.tx
             .send_async(Event::SendLinkTracked {
                 link_id,
@@ -2672,7 +2684,8 @@ impl RnsNode {
     ) -> Result<crate::link_send::LinkSendReceipt, crate::link_send::LinkSendError> {
         use crate::link_send::{Completion, LinkSendError};
         let permit = self.tx.link_send_pool().try_acquire()?;
-        let (completion, receipt) = Completion::new(permit);
+        let tracking = self.tx.link_send_pool().track(link_id, false);
+        let (completion, receipt) = Completion::new_tracked(permit, tracking);
         self.tx
             .try_send(Event::SendLinkTracked {
                 link_id,

--- a/rns-net/src/node.rs
+++ b/rns-net/src/node.rs
@@ -2629,22 +2629,62 @@ impl RnsNode {
             .map_err(|_| SendError)
     }
 
-    /// Send data on a link with a given context.
-    pub fn send_on_link(
+    /// Wait for capacity and transmit a Link packet through its interface writer.
+    ///
+    /// Success means the underlying transport accepted the complete packet,
+    /// not that the peer received or acknowledged it. Cancellation before
+    /// admission sends nothing; after admission, dropping this future does not
+    /// cancel transmission. This future is independent of any async runtime.
+    /// The driver's configured event capacity also bounds the total number of
+    /// admitted Link sends, including frames waiting for an interface or write.
+    /// A transmission error can follow a partial write; only QueueFull from the
+    /// try API guarantees that retrying cannot duplicate an admitted packet.
+    pub async fn send_on_link(
         &self,
         link_id: [u8; 16],
         data: Vec<u8>,
         context: u8,
-    ) -> Result<(), SendError> {
-        self.reject_new_work_if_draining()?;
+    ) -> Result<(), crate::link_send::LinkSendError> {
+        use crate::link_send::Completion;
+        let permit = self.tx.link_send_pool().acquire().await?;
+        let (completion, receipt) = Completion::new(permit);
         self.tx
-            .send(Event::SendOnLink {
+            .send_async(Event::SendLinkTracked {
                 link_id,
                 data,
                 context,
-                response_tx: None,
+                completion,
             })
-            .map_err(|_| SendError)
+            .await?;
+        receipt.await
+    }
+
+    /// Try to admit a Link send without waiting for capacity.
+    ///
+    /// A successful return is a receipt, not a transmission result. Await the
+    /// receipt for exactly the same completion contract as `send_on_link`.
+    /// QueueFull means nothing was admitted and the caller may retry.
+    pub fn try_send_on_link(
+        &self,
+        link_id: [u8; 16],
+        data: Vec<u8>,
+        context: u8,
+    ) -> Result<crate::link_send::LinkSendReceipt, crate::link_send::LinkSendError> {
+        use crate::link_send::{Completion, LinkSendError};
+        let permit = self.tx.link_send_pool().try_acquire()?;
+        let (completion, receipt) = Completion::new(permit);
+        self.tx
+            .try_send(Event::SendLinkTracked {
+                link_id,
+                data,
+                context,
+                completion,
+            })
+            .map_err(|error| match error {
+                std::sync::mpsc::TrySendError::Full(_) => LinkSendError::QueueFull,
+                std::sync::mpsc::TrySendError::Disconnected(_) => LinkSendError::DriverStopped,
+            })?;
+        Ok(receipt)
     }
 
     /// Admit a best-effort direct Link datagram without blocking on queue space.

--- a/rns-net/src/node.rs
+++ b/rns-net/src/node.rs
@@ -2647,7 +2647,8 @@ impl RnsNode {
     /// admission sends nothing; after admission, dropping this future does not
     /// cancel transmission. This future is independent of any async runtime.
     /// The driver's configured event capacity also bounds the total number of
-    /// admitted Link sends, including frames waiting for an interface or write.
+    /// admitted confirmed sends (Links, packets and announcements), including
+    /// frames waiting for an interface or write.
     /// A transmission error can follow a partial write; only QueueFull from the
     /// try API guarantees that retrying cannot duplicate an admitted packet.
     pub async fn send_on_link(
@@ -2735,17 +2736,162 @@ impl RnsNode {
             })?
     }
 
-    /// Build and broadcast an announce for a destination.
+    /// Wait for capacity, then transmit an announcement on all selected local interfaces.
+    ///
+    /// Success means all selected writers accepted the complete packet, not
+    /// remote delivery or subsequent relay. An error can follow partial delivery
+    /// on one or more interfaces. No eligible interface returns `NoRoute`.
+    /// Cancelling before admission sends nothing; after admission, transmission
+    /// continues. Shared-client replay metadata travels in the same admitted
+    /// event as the packet, never in a separate event from a rejected send.
+    pub async fn announce(
+        &self,
+        dest: &crate::destination::Destination,
+        identity: &Identity,
+        app_data: Option<&[u8]>,
+    ) -> Result<(), crate::TransmissionError> {
+        let permit = self.tx.link_send_pool().acquire().await?;
+        let (packet, replay) = self
+            .build_announce(dest, identity, app_data)
+            .map_err(|_| crate::TransmissionError::PacketBuildFailed)?;
+        let (completion, receipt) = crate::link_send::Completion::new(permit);
+        self.tx
+            .send_async(Event::SendOutboundTracked {
+                raw: packet.raw,
+                dest_type: dest.dest_type.to_wire_constant(),
+                replay,
+                completion,
+            })
+            .await?;
+        receipt.await
+    }
+
+    /// Try admission immediately; await the receipt for the exact same result
+    /// as `announce`. `QueueFull` guarantees nothing was admitted.
+    pub fn try_announce(
+        &self,
+        dest: &crate::destination::Destination,
+        identity: &Identity,
+        app_data: Option<&[u8]>,
+    ) -> Result<crate::TransmissionReceipt, crate::TransmissionError> {
+        let permit = self.tx.link_send_pool().try_acquire()?;
+        let (packet, replay) = self
+            .build_announce(dest, identity, app_data)
+            .map_err(|_| crate::TransmissionError::PacketBuildFailed)?;
+        let (completion, receipt) = crate::link_send::Completion::new(permit);
+        self.try_confirmed_event(Event::SendOutboundTracked {
+            raw: packet.raw,
+            dest_type: dest.dest_type.to_wire_constant(),
+            replay,
+            completion,
+        })?;
+        Ok(receipt)
+    }
+
+    /// Wait for capacity and local transmission, returning the hash for proof tracking.
+    ///
+    /// Uses the same all-selected-writers contract as `announce` and the
+    /// same admission/completion capacity as `send_on_link`. No remote delivery
+    /// is promised; errors may follow partial transmission. Dropping an admitted
+    /// future does not cancel its send. No async runtime is required.
+    pub async fn send_packet(
+        &self,
+        dest: &crate::destination::Destination,
+        data: &[u8],
+    ) -> Result<rns_core::types::PacketHash, crate::TransmissionError> {
+        let permit = self.tx.link_send_pool().acquire().await?;
+        let packet = self
+            .build_packet(dest, data)
+            .map_err(|_| crate::TransmissionError::PacketBuildFailed)?;
+        let hash = rns_core::types::PacketHash(packet.packet_hash);
+        let (completion, receipt) = crate::link_send::Completion::new(permit);
+        self.tx
+            .send_async(Event::SendOutboundTracked {
+                raw: packet.raw,
+                dest_type: dest.dest_type.to_wire_constant(),
+                replay: None,
+                completion,
+            })
+            .await?;
+        receipt.await?;
+        Ok(hash)
+    }
+
+    /// Try admission immediately. The receipt exposes the packet hash and
+    /// resolves to the same result as `send_packet`, after local writes.
+    /// `QueueFull` guarantees nothing was admitted and is safe to retry.
+    pub fn try_send_packet(
+        &self,
+        dest: &crate::destination::Destination,
+        data: &[u8],
+    ) -> Result<crate::PacketSendReceipt, crate::TransmissionError> {
+        let permit = self.tx.link_send_pool().try_acquire()?;
+        let packet = self
+            .build_packet(dest, data)
+            .map_err(|_| crate::TransmissionError::PacketBuildFailed)?;
+        let hash = rns_core::types::PacketHash(packet.packet_hash);
+        let (completion, receipt) = crate::link_send::Completion::new(permit);
+        self.try_confirmed_event(Event::SendOutboundTracked {
+            raw: packet.raw,
+            dest_type: dest.dest_type.to_wire_constant(),
+            replay: None,
+            completion,
+        })?;
+        Ok(crate::PacketSendReceipt {
+            completion: receipt,
+            hash,
+        })
+    }
+
+    fn try_confirmed_event(&self, event: Event) -> Result<(), crate::TransmissionError> {
+        self.tx.try_send(event).map_err(|error| match error {
+            std::sync::mpsc::TrySendError::Full(_) => crate::TransmissionError::QueueFull,
+            std::sync::mpsc::TrySendError::Disconnected(_) => {
+                crate::TransmissionError::DriverStopped
+            }
+        })
+    }
+
+    /// Build and broadcast an announce for a destination (queue-only compatibility API).
+    ///
+    /// Success means driver submission, not transmission. Use `announce`
+    /// or `try_announce` for confirmed local transmission.
     ///
     /// The identity is used to sign the announce. Must be the identity that
     /// owns the destination (i.e. `identity.hash()` matches `dest.identity_hash`).
-    pub fn announce(
+    pub fn announce_queued(
         &self,
         dest: &crate::destination::Destination,
         identity: &Identity,
         app_data: Option<&[u8]>,
     ) -> Result<(), SendError> {
         self.reject_new_work_if_draining()?;
+        let (packet, replay) = self.build_announce(dest, identity, app_data)?;
+        if let Some(replay) = replay {
+            self.tx
+                .send(Event::StoreSharedAnnounce {
+                    dest_hash: replay.dest_hash,
+                    name_hash: replay.name_hash,
+                    identity_prv_key: replay.identity_prv_key,
+                    app_data: replay.app_data,
+                })
+                .map_err(|_| SendError)?;
+        }
+        self.send_raw(packet.raw, dest.dest_type.to_wire_constant(), None)
+    }
+
+    fn build_announce(
+        &self,
+        dest: &crate::destination::Destination,
+        identity: &Identity,
+        app_data: Option<&[u8]>,
+    ) -> Result<
+        (
+            rns_core::packet::RawPacket,
+            Option<Box<crate::common::event::AnnounceReplay>>,
+        ),
+        SendError,
+    > {
         let name_hash = rns_core::destination::name_hash(
             &dest.app_name,
             &dest.aspects.iter().map(|s| s.as_str()).collect::<Vec<_>>(),
@@ -2792,32 +2938,51 @@ impl RnsNode {
         )
         .map_err(|_| SendError)?;
 
-        if dest.dest_type == rns_core::types::DestinationType::Single {
-            if let Some(identity_prv_key) = identity.get_private_key() {
-                self.tx
-                    .send(Event::StoreSharedAnnounce {
-                        dest_hash: dest.hash.0,
-                        name_hash,
-                        identity_prv_key,
-                        app_data: app_data.map(|d| d.to_vec()),
-                    })
-                    .map_err(|_| SendError)?;
-            }
-        }
-
-        self.send_raw(packet.raw, dest.dest_type.to_wire_constant(), None)
+        let replay = if dest.dest_type == rns_core::types::DestinationType::Single {
+            identity.get_private_key().map(|identity_prv_key| {
+                Box::new(crate::common::event::AnnounceReplay {
+                    dest_hash: dest.hash.0,
+                    name_hash,
+                    identity_prv_key,
+                    app_data: app_data.map(|d| d.to_vec()),
+                })
+            })
+        } else {
+            None
+        };
+        Ok((packet, replay))
     }
 
-    /// Send an encrypted (SINGLE) or plaintext (PLAIN) packet to a destination.
+    /// Queue an encrypted (SINGLE) or plaintext (PLAIN) packet to a destination.
+    ///
+    /// Queue-only compatibility API: use `send_packet` or `try_send_packet`
+    /// for confirmed local transmission. The returned hash does not mean sent.
     ///
     /// For SINGLE destinations, `dest.public_key` must be set (OUT direction).
     /// Returns the packet hash for proof tracking.
-    pub fn send_packet(
+    pub fn send_packet_queued(
         &self,
         dest: &crate::destination::Destination,
         data: &[u8],
     ) -> Result<rns_core::types::PacketHash, SendError> {
         self.reject_new_work_if_draining()?;
+        let packet = self.build_packet(dest, data)?;
+        let packet_hash = rns_core::types::PacketHash(packet.packet_hash);
+        self.tx
+            .send(Event::SendOutbound {
+                raw: packet.raw,
+                dest_type: dest.dest_type.to_wire_constant(),
+                attached_interface: None,
+            })
+            .map_err(|_| SendError)?;
+        Ok(packet_hash)
+    }
+
+    fn build_packet(
+        &self,
+        dest: &crate::destination::Destination,
+        data: &[u8],
+    ) -> Result<rns_core::packet::RawPacket, SendError> {
         use rns_core::types::DestinationType;
 
         let payload = match dest.dest_type {
@@ -2844,17 +3009,7 @@ impl RnsNode {
         )
         .map_err(|_| SendError)?;
 
-        let packet_hash = rns_core::types::PacketHash(packet.packet_hash);
-
-        self.tx
-            .send(Event::SendOutbound {
-                raw: packet.raw,
-                dest_type: dest.dest_type.to_wire_constant(),
-                attached_interface: None,
-            })
-            .map_err(|_| SendError)?;
-
-        Ok(packet_hash)
+        Ok(packet)
     }
 
     fn encrypt_single_payload(
@@ -3572,7 +3727,7 @@ mod tests {
         };
         let dest = crate::destination::Destination::single_out("test", &["ratchet"], &announced);
 
-        node.send_packet(&dest, b"hello").unwrap();
+        node.send_packet_queued(&dest, b"hello").unwrap();
         assert_eq!(
             store.current_calls.lock().unwrap().as_slice(),
             &[dest.hash.0]
@@ -5050,7 +5205,7 @@ enable_transport = False
             .unwrap();
 
         // Announce should succeed (though no interfaces to send on)
-        let result = node.announce(&dest, &identity, Some(b"hello"));
+        let result = node.announce_queued(&dest, &identity, Some(b"hello"));
         assert!(result.is_ok());
 
         node.shutdown();
@@ -5310,7 +5465,7 @@ enable_transport = False
         let dest = crate::destination::Destination::plain("drain-test", &["send"]);
 
         node.begin_drain(Duration::from_secs(1)).unwrap();
-        assert!(node.send_packet(&dest, b"hello").is_err());
+        assert!(node.send_packet_queued(&dest, b"hello").is_err());
 
         node.shutdown();
     }
@@ -5382,7 +5537,7 @@ enable_transport = False
         .unwrap();
 
         let dest = crate::destination::Destination::plain("test", &["echo"]);
-        let result = node.send_packet(&dest, b"hello world");
+        let result = node.send_packet_queued(&dest, b"hello world");
         assert!(result.is_ok());
 
         let packet_hash = result.unwrap();
@@ -5467,7 +5622,7 @@ enable_transport = False
             &["echo"],
             rns_core::types::IdentityHash([0x42; 16]),
         );
-        let result = node.send_packet(&dest, b"hello");
+        let result = node.send_packet_queued(&dest, b"hello");
         assert!(result.is_err(), "single_in has no public_key, should fail");
 
         node.shutdown();
@@ -5554,7 +5709,7 @@ enable_transport = False
         };
         let dest = crate::destination::Destination::single_out("test", &["echo"], &recalled);
 
-        let result = node.send_packet(&dest, b"secret message");
+        let result = node.send_packet_queued(&dest, b"secret message");
         assert!(result.is_ok());
 
         let packet_hash = result.unwrap();

--- a/rns-net/src/shared_client.rs
+++ b/rns-net/src/shared_client.rs
@@ -136,6 +136,13 @@ impl RnsNode {
         };
 
         let writer = crate::interface::local::start_client(local_config, tx.clone())?;
+        let (writer, async_writer_metrics) = crate::interface::wrap_async_writer(
+            writer,
+            id,
+            &info.name,
+            tx.clone(),
+            driver.interface_writer_queue_capacity,
+        );
 
         driver.engine.register_interface(info.clone());
         driver.interfaces.insert(
@@ -144,7 +151,7 @@ impl RnsNode {
                 id,
                 info,
                 writer,
-                async_writer_metrics: None,
+                async_writer_metrics: Some(async_writer_metrics),
                 enabled: true,
                 online: false,
                 dynamic: false,
@@ -396,6 +403,13 @@ pub fn bench_shared_client_replay_once(
     };
 
     let writer = crate::interface::local::start_client(local_config, tx.clone())?;
+    let (writer, async_writer_metrics) = crate::interface::wrap_async_writer(
+        writer,
+        id,
+        &info.name,
+        tx.clone(),
+        driver.interface_writer_queue_capacity,
+    );
     driver.engine.register_interface(info.clone());
     driver.interfaces.insert(
         id,
@@ -403,7 +417,7 @@ pub fn bench_shared_client_replay_once(
             id,
             info,
             writer,
-            async_writer_metrics: None,
+            async_writer_metrics: Some(async_writer_metrics),
             enabled: true,
             online: false,
             dynamic: false,

--- a/rns-net/src/shared_client.rs
+++ b/rns-net/src/shared_client.rs
@@ -699,7 +699,8 @@ mod tests {
         );
         node.register_destination(dest.hash.0, dest.dest_type.to_wire_constant())
             .unwrap();
-        node.announce(&dest, &identity, Some(b"hello")).unwrap();
+        node.announce_queued(&dest, &identity, Some(b"hello"))
+            .unwrap();
 
         let mut stream1 = accepted1_rx.recv_timeout(Duration::from_secs(2)).unwrap();
         stream1

--- a/rns-net/tests/e2e.rs
+++ b/rns-net/tests/e2e.rs
@@ -373,7 +373,7 @@ fn announce_with_retry(
     remote_rx: &mpsc::Receiver<TestEvent>,
 ) -> Option<AnnouncedIdentity> {
     for _ in 0..10 {
-        let _ = node.announce(dest, identity, app_data);
+        let _ = futures::executor::block_on(node.announce(dest, identity, app_data));
         if let Some(announced) = wait_for_announce(remote_rx, &dest.hash, Duration::from_secs(2)) {
             return Some(announced);
         }
@@ -1394,7 +1394,7 @@ fn test_announce_propagation() {
     std::thread::sleep(SETTLE);
 
     alice_node
-        .announce(&alice_dest, &alice_identity, Some(b"hello"))
+        .announce_queued(&alice_dest, &alice_identity, Some(b"hello"))
         .unwrap();
 
     let announced = wait_for_announce(&bob_rx, &alice_dest.hash, TIMEOUT)
@@ -1438,7 +1438,7 @@ fn test_announce_binary_app_data() {
     OsRng.fill_bytes(&mut binary_data);
 
     alice_node
-        .announce(&alice_dest, &alice_identity, Some(&binary_data))
+        .announce_queued(&alice_dest, &alice_identity, Some(&binary_data))
         .unwrap();
 
     let announced = wait_for_announce(&bob_rx, &alice_dest.hash, TIMEOUT)
@@ -1488,7 +1488,7 @@ fn test_announce_relay_respects_zero_ttl() {
     std::thread::sleep(SETTLE);
 
     alice_node
-        .announce(&alice_dest, &alice_identity, Some(b"ttl-expire"))
+        .announce_queued(&alice_dest, &alice_identity, Some(b"ttl-expire"))
         .unwrap();
 
     let announced = wait_for_announce(&bob_rx, &alice_dest.hash, Duration::from_secs(3));
@@ -1537,7 +1537,7 @@ fn test_announce_relay_respects_max_bytes() {
 
     let large_app_data = vec![0xAB; 32];
     alice_node
-        .announce(&alice_dest, &alice_identity, Some(&large_app_data))
+        .announce_queued(&alice_dest, &alice_identity, Some(&large_app_data))
         .unwrap();
 
     let announced = wait_for_announce(&bob_rx, &alice_dest.hash, Duration::from_secs(3));
@@ -1626,7 +1626,7 @@ fn test_re_announce_updated_app_data() {
 
     // First announce with v1
     alice_node
-        .announce(&alice_dest, &alice_identity, Some(b"v1"))
+        .announce_queued(&alice_dest, &alice_identity, Some(b"v1"))
         .unwrap();
 
     let first = wait_for_announce(&bob_rx, &alice_dest.hash, TIMEOUT)
@@ -1641,7 +1641,7 @@ fn test_re_announce_updated_app_data() {
     let mut got_v2 = false;
     for _attempt in 0..3 {
         alice_node
-            .announce(&alice_dest, &alice_identity, Some(b"v2"))
+            .announce_queued(&alice_dest, &alice_identity, Some(b"v2"))
             .unwrap();
 
         if wait_for_event(&bob_rx, Duration::from_secs(8), |event| match event {
@@ -1724,7 +1724,7 @@ fn test_single_message_delivery() {
 
     let dest_to_bob = Destination::single_out(APP_NAME, &["msg", "rx"], &bob_announced);
     let plaintext = b"Hello Bob from Alice!";
-    alice_node.send_packet(&dest_to_bob, plaintext).unwrap();
+    futures::executor::block_on(alice_node.send_packet(&dest_to_bob, plaintext)).unwrap();
 
     let (_, raw, _) = wait_for_delivery(&bob_rx, TIMEOUT).expect("Bob did not receive message");
     let decrypted = decrypt_delivery(&raw, &bob_id).expect("Decryption failed");
@@ -1753,11 +1753,15 @@ fn test_single_bidirectional() {
 
     // Alice → Bob
     let dest_to_bob = Destination::single_out(APP_NAME, &["msg", "rx"], &bob_announced);
-    alice_node.send_packet(&dest_to_bob, b"A->B").unwrap();
+    alice_node
+        .send_packet_queued(&dest_to_bob, b"A->B")
+        .unwrap();
 
     // Bob → Alice
     let dest_to_alice = Destination::single_out(APP_NAME, &["msg", "rx"], &alice_announced);
-    bob_node.send_packet(&dest_to_alice, b"B->A").unwrap();
+    bob_node
+        .send_packet_queued(&dest_to_alice, b"B->A")
+        .unwrap();
 
     let (_, bob_raw, _) = wait_for_delivery(&bob_rx, TIMEOUT).expect("Bob did not receive");
     let bob_plain = decrypt_delivery(&bob_raw, &bob_id).expect("Bob decrypt failed");
@@ -1793,7 +1797,7 @@ fn test_single_multiple_sequential() {
     for i in 0..5 {
         let msg = format!("Message #{}", i);
         alice_node
-            .send_packet(&dest_to_bob, msg.as_bytes())
+            .send_packet_queued(&dest_to_bob, msg.as_bytes())
             .unwrap();
 
         let (_, raw, _) = wait_for_delivery(&bob_rx, TIMEOUT)
@@ -1824,7 +1828,7 @@ fn test_single_empty_payload() {
     ) = setup_two_peers_announced();
 
     let dest_to_bob = Destination::single_out(APP_NAME, &["msg", "rx"], &bob_announced);
-    alice_node.send_packet(&dest_to_bob, b"").unwrap();
+    alice_node.send_packet_queued(&dest_to_bob, b"").unwrap();
 
     let (_, raw, _) =
         wait_for_delivery(&bob_rx, TIMEOUT).expect("Bob did not receive empty message");
@@ -1945,7 +1949,11 @@ fn test_plain_message_delivery() {
 
     std::thread::sleep(SETTLE);
 
-    alice_node.send_packet(&plain_dest, b"plain text").unwrap();
+    alice_node
+        .try_send_packet(&plain_dest, b"plain text")
+        .unwrap()
+        .wait()
+        .unwrap();
 
     let (_, raw, _) =
         wait_for_delivery(&bob_rx, TIMEOUT).expect("Bob did not receive plain message");
@@ -1974,7 +1982,9 @@ fn test_single_duplicate_packet_dropped_until_fifo_eviction() {
 
     let dest_to_bob = Destination::single_out(APP_NAME, &["msg", "rx"], &bob_announced);
 
-    let hash1 = alice_node.send_packet(&dest_to_bob, b"packet-one").unwrap();
+    let hash1 = alice_node
+        .send_packet_queued(&dest_to_bob, b"packet-one")
+        .unwrap();
     let (_, raw1, recv_hash1) =
         wait_for_delivery(&bob_rx, TIMEOUT).expect("Bob did not receive first single packet");
     assert_eq!(recv_hash1, hash1);
@@ -1987,11 +1997,13 @@ fn test_single_duplicate_packet_dropped_until_fifo_eviction() {
         "duplicate single packet should be suppressed"
     );
 
-    alice_node.send_packet(&dest_to_bob, b"packet-two").unwrap();
+    alice_node
+        .send_packet_queued(&dest_to_bob, b"packet-two")
+        .unwrap();
     wait_for_delivery(&bob_rx, TIMEOUT).expect("Bob did not receive second unique single packet");
 
     alice_node
-        .send_packet(&dest_to_bob, b"packet-three")
+        .send_packet_queued(&dest_to_bob, b"packet-three")
         .unwrap();
     wait_for_delivery(&bob_rx, TIMEOUT).expect("Bob did not receive third unique single packet");
 
@@ -2027,12 +2039,16 @@ fn test_single_duplicate_does_not_refresh_recency() {
 
     let dest_to_bob = Destination::single_out(APP_NAME, &["msg", "rx"], &bob_announced);
 
-    let oldest_hash = alice_node.send_packet(&dest_to_bob, b"oldest").unwrap();
+    let oldest_hash = alice_node
+        .send_packet_queued(&dest_to_bob, b"oldest")
+        .unwrap();
     let (_, oldest_raw, recv_oldest_hash) =
         wait_for_delivery(&bob_rx, TIMEOUT).expect("Bob did not receive oldest packet");
     assert_eq!(recv_oldest_hash, oldest_hash);
 
-    let newer_hash = alice_node.send_packet(&dest_to_bob, b"newer").unwrap();
+    let newer_hash = alice_node
+        .send_packet_queued(&dest_to_bob, b"newer")
+        .unwrap();
     let (_, newer_raw, recv_newer_hash) =
         wait_for_delivery(&bob_rx, TIMEOUT).expect("Bob did not receive newer packet");
     assert_eq!(recv_newer_hash, newer_hash);
@@ -2049,7 +2065,9 @@ fn test_single_duplicate_does_not_refresh_recency() {
         "duplicate oldest packet should be suppressed"
     );
 
-    alice_node.send_packet(&dest_to_bob, b"fresh").unwrap();
+    alice_node
+        .send_packet_queued(&dest_to_bob, b"fresh")
+        .unwrap();
     wait_for_delivery(&bob_rx, TIMEOUT).expect("Bob did not receive fresh packet");
 
     alice_node
@@ -2196,7 +2214,7 @@ fn test_group_message_delivery() {
     std::thread::sleep(SETTLE);
 
     alice_node
-        .send_packet(&group_dest_sender, b"group message")
+        .send_packet_queued(&group_dest_sender, b"group message")
         .unwrap();
 
     let (_, raw, _) =
@@ -2325,7 +2343,7 @@ fn test_group_wrong_key_fails() {
     std::thread::sleep(SETTLE);
 
     alice_node
-        .send_packet(&group_dest_sender, b"secret")
+        .send_packet_queued(&group_dest_sender, b"secret")
         .unwrap();
 
     let (_, raw, _) =
@@ -2359,7 +2377,9 @@ fn test_prove_all() {
     ) = setup_two_peers_announced();
 
     let dest_to_bob = Destination::single_out(APP_NAME, &["msg", "rx"], &bob_announced);
-    let pkt_hash = alice_node.send_packet(&dest_to_bob, b"prove me").unwrap();
+    let pkt_hash = alice_node
+        .send_packet_queued(&dest_to_bob, b"prove me")
+        .unwrap();
 
     let (proof_hash, rtt) =
         wait_for_proof(&alice_rx, TIMEOUT).expect("Alice did not receive proof");
@@ -2423,7 +2443,9 @@ fn test_prove_app_conditional() {
 
     // First send: proof_flag=true → should get proof
     let dest_to_bob = Destination::single_out(APP_NAME, &["prove", "app"], &bob_ann);
-    let pkt1 = alice_node.send_packet(&dest_to_bob, b"first").unwrap();
+    let pkt1 = alice_node
+        .send_packet_queued(&dest_to_bob, b"first")
+        .unwrap();
     let proof1 = wait_for_proof(&alice_rx, TIMEOUT);
     assert!(proof1.is_some(), "Should receive proof when flag=true");
     assert_eq!(proof1.unwrap().0, pkt1);
@@ -2433,7 +2455,9 @@ fn test_prove_app_conditional() {
     std::thread::sleep(Duration::from_millis(200));
 
     // Second send: proof_flag=false → no proof
-    let _pkt2 = alice_node.send_packet(&dest_to_bob, b"second").unwrap();
+    let _pkt2 = alice_node
+        .send_packet_queued(&dest_to_bob, b"second")
+        .unwrap();
     let proof2 = wait_for_proof(&alice_rx, Duration::from_secs(3));
     assert!(proof2.is_none(), "Should NOT receive proof when flag=false");
 
@@ -2491,7 +2515,7 @@ fn test_prove_none() {
 
     let dest_to_bob = Destination::single_out(APP_NAME, &["prove", "none"], &bob_ann);
     alice_node
-        .send_packet(&dest_to_bob, b"no proof expected")
+        .send_packet_queued(&dest_to_bob, b"no proof expected")
         .unwrap();
 
     let proof = wait_for_proof(&alice_rx, Duration::from_secs(3));
@@ -2524,7 +2548,9 @@ fn test_multihop_message_delivery() {
     ) = setup_two_peers_announced();
 
     let dest_to_bob = Destination::single_out(APP_NAME, &["msg", "rx"], &bob_announced);
-    alice_node.send_packet(&dest_to_bob, b"multi-hop").unwrap();
+    alice_node
+        .send_packet_queued(&dest_to_bob, b"multi-hop")
+        .unwrap();
 
     let (_, raw, _) =
         wait_for_delivery(&bob_rx, TIMEOUT).expect("Bob did not receive multi-hop message");
@@ -3644,10 +3670,10 @@ fn test_udp_announce_and_message() {
 
     // Announce
     alice_node
-        .announce(&alice_dest, &alice_identity, Some(b"Alice-UDP"))
+        .announce_queued(&alice_dest, &alice_identity, Some(b"Alice-UDP"))
         .unwrap();
     bob_node
-        .announce(&bob_dest, &bob_identity, Some(b"Bob-UDP"))
+        .announce_queued(&bob_dest, &bob_identity, Some(b"Bob-UDP"))
         .unwrap();
 
     let bob_announced = wait_for_announce(&alice_rx, &bob_dest.hash, TIMEOUT)
@@ -3657,7 +3683,9 @@ fn test_udp_announce_and_message() {
 
     // Send message
     let dest_to_bob = Destination::single_out(APP_NAME, &["udp", "test"], &bob_announced);
-    alice_node.send_packet(&dest_to_bob, b"UDP hello").unwrap();
+    alice_node
+        .send_packet_queued(&dest_to_bob, b"UDP hello")
+        .unwrap();
 
     let (_, raw, _) = wait_for_delivery(&bob_rx, TIMEOUT).expect("Bob did not receive UDP message");
     let decrypted = decrypt_delivery(&raw, &bob_identity).expect("UDP decrypt failed");
@@ -3700,7 +3728,7 @@ fn test_rapid_announces() {
     for i in 0..10 {
         let data = format!("rapid-{}", i);
         alice_node
-            .announce(&alice_dest, &alice_identity, Some(data.as_bytes()))
+            .announce_queued(&alice_dest, &alice_identity, Some(data.as_bytes()))
             .unwrap();
     }
 
@@ -5224,7 +5252,7 @@ fn test_issue4_shared_client_announce_reaches_remote() {
 
     // Alice (shared client) announces
     alice_node
-        .announce(&alice_dest, &alice_id, Some(b"issue4"))
+        .announce_queued(&alice_dest, &alice_id, Some(b"issue4"))
         .unwrap();
 
     // Bob should receive Alice's announce
@@ -5298,7 +5326,9 @@ fn test_issue4_shared_client_message_to_remote_peer() {
     // Alice sends an encrypted message to Bob
     let dest_to_bob = Destination::single_out(APP_NAME, &["issue4", "msg"], &bob_announced);
     let plaintext = b"Hello from shared client!";
-    alice_node.send_packet(&dest_to_bob, plaintext).unwrap();
+    alice_node
+        .send_packet_queued(&dest_to_bob, plaintext)
+        .unwrap();
 
     // Bob should receive the message — but currently doesn't (issue #4)
     let delivery = wait_for_delivery(&bob_rx, Duration::from_secs(5));
@@ -5374,7 +5404,9 @@ fn test_issue4_remote_peer_message_to_shared_client() {
     // Bob sends an encrypted message to Alice
     let dest_to_alice = Destination::single_out(APP_NAME, &["issue4", "rev"], &alice_announced);
     let plaintext = b"Hello shared client from remote!";
-    bob_node.send_packet(&dest_to_alice, plaintext).unwrap();
+    bob_node
+        .send_packet_queued(&dest_to_alice, plaintext)
+        .unwrap();
 
     // Alice should receive the message
     let delivery = wait_for_delivery(&alice_rx, Duration::from_secs(5));

--- a/rns-net/tests/e2e.rs
+++ b/rns-net/tests/e2e.rs
@@ -5500,8 +5500,18 @@ fn issue106_shared_clients_keep_link_alive_and_preserve_burst_data() {
     // immediately splits the resulting 4103-byte frames into LINK_MDU chunks.
     // Queue enough consecutive frames to exercise the same sustained burst.
     let expected: Vec<u8> = (0..(4103 * 64)).map(|index| (index % 251) as u8).collect();
-    for chunk in expected.chunks(rns_core::constants::LINK_MDU) {
-        futures::executor::block_on(alice.send_on_link(link_id, chunk.to_vec(), 0)).unwrap();
+    for (index, chunk) in expected.chunks(rns_core::constants::LINK_MDU).enumerate() {
+        // Both confirmed-send APIs must work on the initial shared-client
+        // connection, not only after reconnect installs a new async writer.
+        if index % 2 == 0 {
+            futures::executor::block_on(alice.send_on_link(link_id, chunk.to_vec(), 0)).unwrap();
+        } else {
+            alice
+                .try_send_on_link(link_id, chunk.to_vec(), 0)
+                .unwrap()
+                .wait()
+                .unwrap();
+        }
     }
     let mut received = Vec::new();
     while received.len() < expected.len() {

--- a/rns-net/tests/e2e.rs
+++ b/rns-net/tests/e2e.rs
@@ -1452,12 +1452,15 @@ fn test_announce_binary_app_data() {
 }
 
 #[test]
-fn test_announce_relay_respects_short_ttl() {
+fn test_announce_relay_respects_zero_ttl() {
     let port = find_free_port();
     let transport = start_transport_node_with_limits(
         port,
         rns_core::constants::HASHLIST_MAXSIZE,
-        Duration::from_millis(50),
+        // A positive TTL can legitimately allow a randomized retransmit
+        // before expiry. Zero ensures expiry before any later relay tick;
+        // positive-TTL boundaries are covered with a controlled core clock.
+        Duration::ZERO,
         rns_core::constants::ANNOUNCE_TABLE_MAX_BYTES,
     );
 

--- a/rns-net/tests/e2e.rs
+++ b/rns-net/tests/e2e.rs
@@ -589,6 +589,9 @@ const KNOWN_DESTINATIONS_TTL: Duration = Duration::from_secs(48 * 60 * 60);
 
 const APP_NAME: &str = "e2e_test";
 
+#[path = "support/issue152.rs"]
+mod issue152;
+
 /// Start a transport node (TCP server) on the given port.
 fn start_transport_node(port: u16) -> RnsNode {
     start_transport_node_with_limits(
@@ -3310,8 +3313,7 @@ fn test_send_on_link() {
         link_id,
     ) = setup_link();
 
-    alice_node
-        .send_on_link(link_id, b"custom data".to_vec(), 0x42)
+    futures::executor::block_on(alice_node.send_on_link(link_id, b"custom data".to_vec(), 0x42))
         .unwrap();
 
     let (ld_lid, ld_ctx, ld_data) =
@@ -5499,7 +5501,7 @@ fn issue106_shared_clients_keep_link_alive_and_preserve_burst_data() {
     // Queue enough consecutive frames to exercise the same sustained burst.
     let expected: Vec<u8> = (0..(4103 * 64)).map(|index| (index % 251) as u8).collect();
     for chunk in expected.chunks(rns_core::constants::LINK_MDU) {
-        alice.send_on_link(link_id, chunk.to_vec(), 0).unwrap();
+        futures::executor::block_on(alice.send_on_link(link_id, chunk.to_vec(), 0)).unwrap();
     }
     let mut received = Vec::new();
     while received.len() < expected.len() {
@@ -5518,7 +5520,7 @@ fn issue106_shared_clients_keep_link_alive_and_preserve_burst_data() {
     // directional 0xff/0xfe keepalive exchange kept both endpoints alive.
     std::thread::sleep(Duration::from_secs(15));
     let after_keepalive = b"issue106 link survived idle keepalive".to_vec();
-    bob.send_on_link(link_id, after_keepalive.clone(), 0)
+    futures::executor::block_on(bob.send_on_link(link_id, after_keepalive.clone(), 0))
         .expect("Bob should still have an active link after the keepalive window");
     let (received_link, context, received_data) = wait_for_link_data(&alice_rx, TIMEOUT)
         .expect("Alice should receive Link data after the keepalive window");

--- a/rns-net/tests/e2e_hooks.rs
+++ b/rns-net/tests/e2e_hooks.rs
@@ -446,7 +446,7 @@ fn announce_bob_to_alice(
     alice_rx: &mpsc::Receiver<TestEvent>,
 ) -> AnnouncedIdentity {
     for _ in 0..10 {
-        let _ = bob_node.announce(bob_dest, bob_id, Some(b"Bob"));
+        let _ = bob_node.announce_queued(bob_dest, bob_id, Some(b"Bob"));
         if let Some(ann) = wait_for_announce(alice_rx, &bob_dest.hash, Duration::from_secs(2)) {
             return ann;
         }
@@ -894,7 +894,9 @@ fn test_packet_logger_does_not_block_delivery() {
     // Alice sends packet to Bob
     let dest_to_bob = Destination::single_out(APP_NAME, &["msg", "rx"], &bob_announced);
     let plaintext = b"Hello through hook!";
-    alice_node.send_packet(&dest_to_bob, plaintext).unwrap();
+    alice_node
+        .send_packet_queued(&dest_to_bob, plaintext)
+        .unwrap();
 
     // Bob should still receive it (packet_logger returns Continue)
     let (_, raw, _) = wait_for_delivery(&bob_rx, TIMEOUT)
@@ -937,7 +939,9 @@ fn test_builtin_hook_does_not_block_delivery() {
 
     let dest_to_bob = Destination::single_out(APP_NAME, &["msg", "rx"], &bob_announced);
     let plaintext = b"Hello through built-in hook!";
-    alice_node.send_packet(&dest_to_bob, plaintext).unwrap();
+    alice_node
+        .send_packet_queued(&dest_to_bob, plaintext)
+        .unwrap();
 
     let (_, raw, _) = wait_for_delivery(&bob_rx, TIMEOUT)
         .expect("Bob did not receive message with built-in hook active");
@@ -1055,7 +1059,7 @@ fn test_load_hook_after_traffic_flowing() {
     // Exchange traffic first (no hooks)
     let dest_to_bob = Destination::single_out(APP_NAME, &["msg", "rx"], &bob_announced);
     alice_node
-        .send_packet(&dest_to_bob, b"before hook")
+        .send_packet_queued(&dest_to_bob, b"before hook")
         .unwrap();
     let (_, raw, _) =
         wait_for_delivery(&bob_rx, TIMEOUT).expect("Bob did not receive pre-hook message");
@@ -1074,7 +1078,9 @@ fn test_load_hook_after_traffic_flowing() {
         .expect("load_hook failed");
 
     // Send another packet — should still be delivered
-    alice_node.send_packet(&dest_to_bob, b"after hook").unwrap();
+    alice_node
+        .send_packet_queued(&dest_to_bob, b"after hook")
+        .unwrap();
     let (_, raw, _) =
         wait_for_delivery(&bob_rx, TIMEOUT).expect("Bob did not receive post-hook message");
     let decrypted = decrypt_delivery(&raw, &bob_id).expect("Decryption failed");
@@ -1115,7 +1121,9 @@ fn test_unload_hook_restores_behavior() {
         .expect("load_hook failed");
 
     // Verify traffic works with hook
-    alice_node.send_packet(&dest_to_bob, b"with hook").unwrap();
+    alice_node
+        .send_packet_queued(&dest_to_bob, b"with hook")
+        .unwrap();
     let (_, raw, _) =
         wait_for_delivery(&bob_rx, TIMEOUT).expect("Bob did not receive message with hook active");
     let decrypted = decrypt_delivery(&raw, &bob_id).expect("Decryption failed");
@@ -1129,7 +1137,7 @@ fn test_unload_hook_restores_behavior() {
 
     // Verify traffic still works after unload
     alice_node
-        .send_packet(&dest_to_bob, b"after unload")
+        .send_packet_queued(&dest_to_bob, b"after unload")
         .unwrap();
     let (_, raw, _) =
         wait_for_delivery(&bob_rx, TIMEOUT).expect("Bob did not receive message after hook unload");
@@ -1180,7 +1188,7 @@ fn test_rate_limiter_drops_excess() {
     // Send a few packets — should pass through (well under threshold)
     for i in 0..3u8 {
         let msg = [b'r', b'l', b'0' + i];
-        alice_node.send_packet(&dest_to_bob, &msg).unwrap();
+        alice_node.send_packet_queued(&dest_to_bob, &msg).unwrap();
         let (_, raw, _) = wait_for_delivery(&bob_rx, TIMEOUT)
             .expect("Bob did not receive message through rate_limiter");
         let decrypted = decrypt_delivery(&raw, &bob_id).expect("Decryption failed");
@@ -1222,7 +1230,7 @@ fn test_allowlist_blocks_unknown() {
     // Bob announces — his dest hash is random, so it should be dropped by the allowlist.
     // Try a few times; none should get through.
     for _ in 0..3 {
-        let _ = bob_node.announce(&bob_dest, &bob_id, Some(b"Bob"));
+        let _ = bob_node.announce_queued(&bob_dest, &bob_id, Some(b"Bob"));
     }
     std::thread::sleep(Duration::from_secs(3));
 
@@ -1270,7 +1278,7 @@ fn test_packet_mirror_does_not_block() {
 
     // Send a packet — should still be delivered normally
     alice_node
-        .send_packet(&dest_to_bob, b"mirror test")
+        .send_packet_queued(&dest_to_bob, b"mirror test")
         .unwrap();
     let (_, raw, _) = wait_for_delivery(&bob_rx, TIMEOUT)
         .expect("Bob did not receive message with packet_mirror active");
@@ -1314,7 +1322,9 @@ fn test_link_guard_loads_and_continues() {
         .expect("load_hook failed");
 
     // Normal traffic should still work (link_guard only acts on link requests)
-    alice_node.send_packet(&dest_to_bob, b"guard test").unwrap();
+    alice_node
+        .send_packet_queued(&dest_to_bob, b"guard test")
+        .unwrap();
     let (_, raw, _) = wait_for_delivery(&bob_rx, TIMEOUT)
         .expect("Bob did not receive message with link_guard active");
     let decrypted = decrypt_delivery(&raw, &bob_id).expect("Decryption failed");
@@ -1393,7 +1403,7 @@ fn test_metrics_does_not_interfere() {
     // Send several packets — all should be delivered
     for i in 0..5u8 {
         let msg = [b'm', b'e', b't', b'0' + i];
-        alice_node.send_packet(&dest_to_bob, &msg).unwrap();
+        alice_node.send_packet_queued(&dest_to_bob, &msg).unwrap();
         let (_, raw, _) = wait_for_delivery(&bob_rx, TIMEOUT)
             .expect("Bob did not receive message with metrics hook active");
         let decrypted = decrypt_delivery(&raw, &bob_id).expect("Decryption failed");

--- a/rns-net/tests/python_interop.rs
+++ b/rns-net/tests/python_interop.rs
@@ -503,7 +503,7 @@ try:
     for line in sys.stdin:
         command = line.strip()
         if command == "announce_py":
-            destination.announce()
+            destination.announce_queued()
             emit("python_announced", dest_hash=destination.hash.hex())
         elif command == "link_rust":
             if rust_destination is None:
@@ -574,7 +574,7 @@ fn python_rns_bidirectional_tcp_interop() {
     );
 
     let python_out = Destination::single_out(APP_NAME, &[PYTHON_ASPECT], &python_live_announce);
-    node.send_packet(&python_out, RUST_TO_PYTHON_PAYLOAD)
+    node.send_packet_queued(&python_out, RUST_TO_PYTHON_PAYLOAD)
         .expect("Rust should send encrypted data to Python destination");
     let python_packet = python.wait_for_event(TIMEOUT, |event| {
         event["event"] == "python_packet" && event["data_hex"] == hex(RUST_TO_PYTHON_PAYLOAD)
@@ -598,7 +598,7 @@ fn python_rns_bidirectional_tcp_interop() {
     );
     assert_eq!(python_reannounce.app_data.as_deref(), Some(PYTHON_APP_DATA));
 
-    node.announce(&rust_dest, &rust_identity, Some(RUST_APP_DATA))
+    node.announce_queued(&rust_dest, &rust_identity, Some(RUST_APP_DATA))
         .expect("Rust announce should send to Python");
     let rust_announce = python.wait_for_event(TIMEOUT, |event| {
         event["event"] == "rust_announce"

--- a/rns-net/tests/python_interop.rs
+++ b/rns-net/tests/python_interop.rs
@@ -648,8 +648,12 @@ fn python_rns_bidirectional_tcp_interop() {
     .expect("Rust should receive Python link data");
     assert_eq!(python_link_data, (0, b"python-to-rust over link".to_vec()));
 
-    node.send_on_link(link_id, b"rust-to-python over link".to_vec(), 0)
-        .expect("Rust should send data over the Python-initiated link");
+    futures::executor::block_on(node.send_on_link(
+        link_id,
+        b"rust-to-python over link".to_vec(),
+        0,
+    ))
+    .expect("Rust should send data over the Python-initiated link");
     let rust_link_data = python.wait_for_event(TIMEOUT, |event| {
         event["event"] == "python_link_packet"
             && event["context"] == 0

--- a/rns-net/tests/python_interop.rs
+++ b/rns-net/tests/python_interop.rs
@@ -503,7 +503,7 @@ try:
     for line in sys.stdin:
         command = line.strip()
         if command == "announce_py":
-            destination.announce_queued()
+            destination.announce()
             emit("python_announced", dest_hash=destination.hash.hex())
         elif command == "link_rust":
             if rust_destination is None:
@@ -574,7 +574,7 @@ fn python_rns_bidirectional_tcp_interop() {
     );
 
     let python_out = Destination::single_out(APP_NAME, &[PYTHON_ASPECT], &python_live_announce);
-    node.send_packet_queued(&python_out, RUST_TO_PYTHON_PAYLOAD)
+    futures::executor::block_on(node.send_packet(&python_out, RUST_TO_PYTHON_PAYLOAD))
         .expect("Rust should send encrypted data to Python destination");
     let python_packet = python.wait_for_event(TIMEOUT, |event| {
         event["event"] == "python_packet" && event["data_hex"] == hex(RUST_TO_PYTHON_PAYLOAD)
@@ -598,7 +598,9 @@ fn python_rns_bidirectional_tcp_interop() {
     );
     assert_eq!(python_reannounce.app_data.as_deref(), Some(PYTHON_APP_DATA));
 
-    node.announce_queued(&rust_dest, &rust_identity, Some(RUST_APP_DATA))
+    node.try_announce(&rust_dest, &rust_identity, Some(RUST_APP_DATA))
+        .expect("Rust announce should be admitted")
+        .wait()
         .expect("Rust announce should send to Python");
     let rust_announce = python.wait_for_event(TIMEOUT, |event| {
         event["event"] == "rust_announce"

--- a/rns-net/tests/support/issue152.rs
+++ b/rns-net/tests/support/issue152.rs
@@ -148,7 +148,7 @@ fn run_burst(async_api: bool) {
     let alice = RnsNode::start(
         NodeConfig {
             interface_writer_queue_capacity: queue_capacity,
-            driver_event_queue_capacity: 8192,
+            driver_event_queue_capacity: PACKETS as usize,
             identity: Some(Identity::new(&mut OsRng)),
             registry: Some(registry),
             interfaces: vec![InterfaceConfig {
@@ -209,6 +209,43 @@ fn run_burst(async_api: bool) {
     }
     // FIFO control-event barrier: all SendOnLink events have been dispatched.
     alice.query(QueryRequest::InterfaceStats).unwrap();
+    assert!(alice.query_link([0; 16]).unwrap().is_none());
+    let status = alice.query_link(link).unwrap().unwrap();
+    assert_eq!(status.pending_send_packets, PACKETS as usize);
+    assert_eq!(status.waiting_send_packets, 0);
+    let listed = alice
+        .links()
+        .unwrap()
+        .into_iter()
+        .find(|entry| entry.link_id == link)
+        .unwrap();
+    assert_eq!(listed.pending_send_packets, status.pending_send_packets);
+    assert_eq!(listed.waiting_send_packets, status.waiting_send_packets);
+
+    // Every admission slot is held by a send to the paused writer. Merely
+    // constructing a future must not count; polling it must count as waiting.
+    let mut waiting = Box::pin(alice.send_on_link(link, b"cancelled".to_vec(), CONTEXT));
+    assert_eq!(
+        alice
+            .query_link(link)
+            .unwrap()
+            .unwrap()
+            .waiting_send_packets,
+        0
+    );
+    assert!(waiting.as_mut().now_or_never().is_none());
+    let status = alice.query_link(link).unwrap().unwrap();
+    assert_eq!(status.pending_send_packets, PACKETS as usize);
+    assert_eq!(status.waiting_send_packets, 1);
+    drop(waiting);
+    assert_eq!(
+        alice
+            .query_link(link)
+            .unwrap()
+            .unwrap()
+            .waiting_send_packets,
+        0
+    );
     // Admission must never be confused with transmission completion.
     for receipt in &mut receipts {
         assert!(
@@ -223,6 +260,17 @@ fn run_burst(async_api: bool) {
     let marker_receipt = alice
         .try_send_on_link(link, marker.clone(), CONTEXT)
         .unwrap();
+    for receipt in receipts {
+        futures::executor::block_on(receipt).unwrap();
+    }
+    marker_receipt.wait().unwrap();
+    // Check local completion before waiting for the receiver to drain its
+    // callback backlog; remote processing is not part of the send contract.
+    let status = alice.query_link(link).unwrap().unwrap();
+    assert_eq!(
+        (status.pending_send_packets, status.waiting_send_packets),
+        (0, 0)
+    );
     let deadline = Instant::now() + Duration::from_secs(60);
     let mut sequences = Vec::new();
     let mut marker_received = false;
@@ -240,10 +288,6 @@ fn run_burst(async_api: bool) {
         sequences.push(u32::from_be_bytes(payload[..4].try_into().unwrap()));
     }
     eprintln!("issue152: queue capacity={queue_capacity}, {PACKETS} sends returned Ok, {} burst packets received, end marker received={marker_received}", sequences.len());
-    for receipt in receipts {
-        futures::executor::block_on(receipt).unwrap();
-    }
-    marker_receipt.wait().unwrap();
     alice.shutdown();
     bob.shutdown();
     assert!(

--- a/rns-net/tests/support/issue152.rs
+++ b/rns-net/tests/support/issue152.rs
@@ -1,0 +1,259 @@
+//! Regression: actual TCP, encryption, routing and receiver callbacks,
+//! with a controlled pause at the sender's concrete writer (no injected drops).
+use super::*;
+use rns_net::interface::{
+    registry::InterfaceRegistry, tcp::TcpClientFactory, InterfaceConfigData, InterfaceFactory,
+    StartContext, StartResult, Writer,
+};
+use std::sync::atomic::{AtomicBool, Ordering};
+
+type SendCompletion<'a> = futures::future::LocalBoxFuture<'a, Result<(), rns_net::LinkSendError>>;
+
+struct PausedTcpFactory {
+    armed: Arc<AtomicBool>,
+    entered: mpsc::Sender<()>,
+    release: Mutex<Option<mpsc::Receiver<()>>>,
+}
+
+struct PausedWriter {
+    inner: Box<dyn Writer>,
+    armed: Arc<AtomicBool>,
+    entered: mpsc::Sender<()>,
+    release: mpsc::Receiver<()>,
+}
+
+impl Writer for PausedWriter {
+    fn send_frame(&mut self, data: &[u8]) -> std::io::Result<()> {
+        if self.armed.swap(false, Ordering::SeqCst) {
+            self.entered.send(()).unwrap();
+            // Also unblocks on sender drop if the test panics.
+            let _ = self.release.recv_timeout(Duration::from_secs(30));
+        }
+        // Model a slow interface even after release, so the queued burst does
+        // not overflow unrelated downstream ingress/relay queues in the control.
+        std::thread::sleep(Duration::from_millis(2));
+        self.inner.send_frame(data)
+    }
+}
+
+impl InterfaceFactory for PausedTcpFactory {
+    fn type_name(&self) -> &str {
+        "TCPClientInterface"
+    }
+
+    fn parse_config(
+        &self,
+        name: &str,
+        id: InterfaceId,
+        params: &std::collections::HashMap<String, String>,
+    ) -> Result<Box<dyn InterfaceConfigData>, String> {
+        TcpClientFactory.parse_config(name, id, params)
+    }
+
+    fn start(
+        &self,
+        config: Box<dyn InterfaceConfigData>,
+        ctx: StartContext,
+    ) -> std::io::Result<StartResult> {
+        match TcpClientFactory.start(config, ctx)? {
+            StartResult::Simple {
+                id,
+                info,
+                writer,
+                interface_type_name,
+            } => Ok(StartResult::Simple {
+                id,
+                info,
+                interface_type_name,
+                writer: Box::new(PausedWriter {
+                    inner: writer,
+                    armed: self.armed.clone(),
+                    entered: self.entered.clone(),
+                    release: self.release.lock().unwrap().take().unwrap(),
+                }),
+            }),
+            _ => panic!("TCP client factory did not return a simple interface"),
+        }
+    }
+}
+
+#[test]
+fn link_burst_survives_writer_backpressure() {
+    run_burst(false);
+}
+
+#[test]
+fn async_link_burst_survives_writer_backpressure() {
+    run_burst(true);
+}
+
+fn run_burst(async_api: bool) {
+    use futures::FutureExt;
+    let queue_capacity = rns_net::interface::DEFAULT_ASYNC_WRITER_QUEUE_CAPACITY;
+    const PACKETS: u32 = 4096;
+    const PAYLOAD_SIZE: usize = 256;
+    const CONTEXT: u8 = 0;
+    let port = find_free_port();
+    let bob_id = Identity::new(&mut OsRng);
+    let bob_dest = Destination::single_in(APP_NAME, &["issue152"], IdentityHash(*bob_id.hash()));
+    let (bob_tx, bob_rx) = mpsc::channel();
+    let bob = RnsNode::start(
+        NodeConfig {
+            // Isolate sender egress saturation from receiver ingress limits.
+            driver_event_queue_capacity: 8192,
+            identity: Some(Identity::from_private_key(
+                &bob_id.get_private_key().unwrap(),
+            )),
+            interfaces: vec![InterfaceConfig {
+                name: "Bob TCP".into(),
+                type_name: "TCPServerInterface".into(),
+                config_data: Box::new(TcpServerConfig {
+                    name: "Bob TCP".into(),
+                    listen_ip: "127.0.0.1".into(),
+                    listen_port: port,
+                    interface_id: InterfaceId(1),
+                    ..Default::default()
+                }),
+                mode: MODE_FULL,
+                gravity: 0,
+                recursive_prs: false,
+                announces_from_internal: true,
+                announces_to_internal: None,
+                ingress_control: Default::default(),
+                ifac: None,
+                discovery: None,
+            }],
+            ..Default::default()
+        },
+        Box::new(TestCallbacks::new(bob_tx)),
+    )
+    .unwrap();
+    bob.register_destination_with_proof(&bob_dest, Some(bob_id.get_private_key().unwrap()))
+        .unwrap();
+    let (prv, public) = extract_sig_keys(&bob_id);
+    bob.register_link_destination(bob_dest.hash.0, prv, public, 0)
+        .unwrap();
+    bob.query(QueryRequest::InterfaceStats).unwrap();
+
+    let armed = Arc::new(AtomicBool::new(false));
+    let (entered_tx, entered_rx) = mpsc::channel();
+    let (release_tx, release_rx) = mpsc::channel();
+    let mut registry = InterfaceRegistry::with_builtins();
+    registry.register(Box::new(PausedTcpFactory {
+        armed: armed.clone(),
+        entered: entered_tx,
+        release: Mutex::new(Some(release_rx)),
+    }));
+    let (alice_tx, alice_rx) = mpsc::channel();
+    let alice = RnsNode::start(
+        NodeConfig {
+            interface_writer_queue_capacity: queue_capacity,
+            driver_event_queue_capacity: 8192,
+            identity: Some(Identity::new(&mut OsRng)),
+            registry: Some(registry),
+            interfaces: vec![InterfaceConfig {
+                name: "Alice paused TCP".into(),
+                type_name: "TCPClientInterface".into(),
+                config_data: Box::new(TcpClientConfig {
+                    name: "Alice paused TCP".into(),
+                    target_port: port,
+                    interface_id: InterfaceId(1),
+                    ..Default::default()
+                }),
+                mode: MODE_FULL,
+                gravity: 0,
+                recursive_prs: false,
+                announces_from_internal: true,
+                announces_to_internal: None,
+                ingress_control: Default::default(),
+                ifac: None,
+                discovery: None,
+            }],
+            ..Default::default()
+        },
+        Box::new(TestCallbacks::new(alice_tx)),
+    )
+    .unwrap();
+    std::thread::sleep(SETTLE);
+    announce_with_retry(&bob, &bob_dest, &bob_id, None, &alice_rx).unwrap();
+    let link = alice.create_link(bob_dest.hash.0, public).unwrap();
+    wait_for_link_established(&alice_rx, TIMEOUT).unwrap();
+    wait_for_link_established(&bob_rx, TIMEOUT).unwrap();
+
+    // A paced control establishes that this Link and payload size work.
+    for sequence in 0..8u32 {
+        let mut payload = vec![0x55; PAYLOAD_SIZE];
+        payload[..4].copy_from_slice(&sequence.to_be_bytes());
+        futures::executor::block_on(alice.send_on_link(link, payload.clone(), CONTEXT)).unwrap();
+        let (received_link, context, received) = wait_for_link_data(&bob_rx, TIMEOUT).unwrap();
+        assert_eq!((received_link, context, received), (link, CONTEXT, payload));
+    }
+
+    armed.store(true, Ordering::SeqCst);
+    let mut receipts: Vec<SendCompletion<'_>> = Vec::new();
+    for sequence in 0..PACKETS {
+        let mut payload = vec![0xAA; PAYLOAD_SIZE];
+        payload[..4].copy_from_slice(&sequence.to_be_bytes());
+        let mut receipt: SendCompletion<'_> = if async_api {
+            Box::pin(alice.send_on_link(link, payload, CONTEXT))
+        } else {
+            Box::pin(alice.try_send_on_link(link, payload, CONTEXT).unwrap())
+        };
+        assert!(receipt.as_mut().now_or_never().is_none());
+        receipts.push(receipt);
+        if sequence == 0 {
+            entered_rx
+                .recv_timeout(TIMEOUT)
+                .expect("writer did not pause");
+        }
+    }
+    // FIFO control-event barrier: all SendOnLink events have been dispatched.
+    alice.query(QueryRequest::InterfaceStats).unwrap();
+    // Admission must never be confused with transmission completion.
+    for receipt in &mut receipts {
+        assert!(
+            (&mut *receipt).now_or_never().is_none(),
+            "receipt completed while writer was paused"
+        );
+    }
+    release_tx.send(()).unwrap();
+    // Let the retry timer expire before sending the end marker.
+    std::thread::sleep(Duration::from_secs(1));
+    let marker = b"issue152-end".to_vec();
+    let marker_receipt = alice
+        .try_send_on_link(link, marker.clone(), CONTEXT)
+        .unwrap();
+    let deadline = Instant::now() + Duration::from_secs(60);
+    let mut sequences = Vec::new();
+    let mut marker_received = false;
+    while let Some(remaining) = deadline.checked_duration_since(Instant::now()) {
+        let Some((received_link, context, payload)) = wait_for_link_data(&bob_rx, remaining) else {
+            break;
+        };
+        assert_eq!((received_link, context), (link, CONTEXT));
+        if payload == marker {
+            marker_received = true;
+            break;
+        }
+        assert_eq!(payload.len(), PAYLOAD_SIZE);
+        assert!(payload[4..].iter().all(|byte| *byte == 0xAA));
+        sequences.push(u32::from_be_bytes(payload[..4].try_into().unwrap()));
+    }
+    eprintln!("issue152: queue capacity={queue_capacity}, {PACKETS} sends returned Ok, {} burst packets received, end marker received={marker_received}", sequences.len());
+    for receipt in receipts {
+        futures::executor::block_on(receipt).unwrap();
+    }
+    marker_receipt.wait().unwrap();
+    alice.shutdown();
+    bob.shutdown();
+    assert!(
+        marker_received,
+        "Link did not recover after releasing writer"
+    );
+    assert_eq!(
+        sequences.len(),
+        PACKETS as usize,
+        "successful sends disappeared before TCP transmission"
+    );
+    assert_eq!(sequences, (0..PACKETS).collect::<Vec<_>>());
+}

--- a/rns-tun/src/reticulum.rs
+++ b/rns-tun/src/reticulum.rs
@@ -155,7 +155,7 @@ impl PrivateNode {
 
     pub fn announce_gateway(&self, destination: &Destination) -> io::Result<()> {
         self.node
-            .announce(destination, &self.identity, Some(b"RNTU\x01"))
+            .announce_queued(destination, &self.identity, Some(b"RNTU\x01"))
             .map(|_| ())
             .map_err(node_error)
     }


### PR DESCRIPTION
A 1 MiB burst could return success for all 4,096 raw Link sends while delivering only 257 packets with the default writer queue. Accepted sends now remain pending under interface backpressure, and success is reported only after the interface writer completes the local write.

- `send_on_link(...).await` waits for admission and transmission. `try_send_on_link(...)` returns a receipt with the same transmission result, or rejects immediately when admission is full. Neither guarantees remote delivery.
- `LinkInfoEntry` now exposes `pending_send_packets` (admitted, not yet fully written) and `waiting_send_packets` (polled async sends waiting for admission). Counts follow cancellation, failure, and shutdown; Channel and legacy datagram accounting remain separate.
- `RnsNode::query_link(link_id)` returns the same snapshot as `links()`, or `None` for an unknown link. The controller's link list includes both counters.

This changes the synchronous `send_on_link` API: callers must await it or use `try_send_on_link(...)?.wait()`. Repository callers and migration documentation are updated. The futures do not require a particular async runtime.

Additional API consistency: `send_packet(...).await` and `announce(...).await` now use the same confirmed local-transmission contract, with `try_send_packet` and `try_announce` returning awaitable receipts. Broadcast success waits for all selected writers; errors may follow partial transmission, and completion waits for every selected write to settle. All confirmed sends share bounded admission capacity. Packet receipts expose their hash before completion for proof tracking.

The old synchronous packet/announcement behavior is explicitly named `send_packet_queued` / `announce_queued`. Existing submission-only callers use those names; the message example and representative E2E paths use the confirmed APIs. Shared-client replay metadata travels with the admitted announcement, so cancelled/rejected admission has no replay side effects.

Validation on the latest implementation: 955 network unit tests, 45 controller tests, all 56 network E2E tests both with and without hooks, focused completion tests with hooks, strict rns-net Clippy, workspace/all-target compilation, and the encrypted message/proof example pass locally. No-default-features compilation passes with existing warnings. Tests cover bounded admission, cancellation, shutdown, packet hashes, no-route/drain errors, multi-interface backpressure, and partial write failures. GitHub CI for the latest commit still needs to complete.

Fixes #152.
